### PR TITLE
typo fix

### DIFF
--- a/docs/ja/guide/getting-started/docker-compose.md
+++ b/docs/ja/guide/getting-started/docker-compose.md
@@ -81,7 +81,7 @@ docker-compose stop
 既存の Docker コンテナと Docker イメージを削除します。
 
 ```text
-docker-compose rm app　mongodb elasticseach
+docker-compose rm app mongo elasticseach
 docker rmi weseek/growi:3
 ```
 


### PR DESCRIPTION
## 修正点
- 全角スペースを半角スペースに修正
- `mongodb`を`mongo`に修正 (ref: [docker-compose.yml#L38][docker-compose.yml#L38])

## 気になった点
- [weseek/growi-docker-composeの説明][readme.md]では`app`のみremoveしていますが、
  growi-docsの`app mongo elasticearch`が正でよろしいでしょうか？

[docker-compose.yml#L38]: https://github.com/weseek/growi-docker-compose/blob/master/docker-compose.yml#L38
[readme.md]: https://github.com/weseek/growi-docker-compose/blob/master/README.md#upgrading-app-container