### PR TITLE
gw698-713-add-env-list-from-growireadme

### DIFF
--- a/docs/en/dev/tips/env-vars.md
+++ b/docs/en/dev/tips/env-vars.md
@@ -8,70 +8,66 @@
 
 |Enviroment Variable|Description|
 |---|---|
-| Required ||
+| **Required** ||
 |`MONGO_URI`| URI to connect to MongoDB. |
-| Option ||
+| **Option** ||
 |`PLUGIN_NAMES_TOBE_LOADED`|Specify plugins to load for development. See [Plugins](/en/dev/plugin/architecture.md).|
 |`DEV_HTTPS`|Start HTTPS express server using self-signed certificate in `resource/certs/localhost`.|
 |`NODE_ENV`| `production` OR `development`.|
 |`PORT`|Server port. default: `3000`.|
-|NO_CDN| If `true`, system doesn't use CDN, all resources will be downloaded from CDN when build client, and served by the GROWI Express server. default: `false`.|
-|ELASTICSEARCH_URI| URI to connect to Elasticearch.|
-|REDIS_URI| URI to connect to Redis (use it as a session store instead of MongoDB).|
-|PASSWORD_SEED| A password seed used by password hash generator.|
-|SECRET_TOKEN| A secret key for verifying the integrity of signed cookies.|
-|SESSION_NAME| The name of the session ID cookie to set in the response by Express. default: `connect.sid`|
-| SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS| If `true`, the system uses only the value of the environment variable as the value of the SAML option that can be set via the environment variable.|
-
-Environment Variables
-======================
-
-    * PUBLISH_OPEN_API: Publish GROWI OpenAPI resources with [ReDoc](https://github.com/Rebilly/ReDoc). Visit `/api-docs`.
-    * FORCE_WIKI_MODE: Forces wiki mode. default: undefined
-        * `public`  : Forces all pages to become public
-        * `private` : Forces all pages to become private
-        * undefined : Publicity will be configured by the admin security page settings
-    * FORMAT_NODE_LOG: If `false`, Output server log as JSON. defautl: `true` (Enabled only when `NODE_ENV=production`)
-* **Option for file uploading**
-    * FILE_UPLOAD: Attached files storage. default: `aws`
-        * `aws` : Amazon Web Service S3 (needs AWS settings on Admin page)
-        * `gcs` : Google Cloud Storage (needs settings with environment variables)
-        * `mongodb` : MongoDB GridFS (Setting-less)
-        * `local` : Server's Local file system (Setting-less)
-        * `none` : Disable file uploading
-    * FILE_UPLOAD_DISABLED: If `true`, file uploading will be disabled. However, the files can be still viewed. Default: `false`
-    * MAX_FILE_SIZE: The maximum file size limit for uploads (bytes). default: `Infinity`
-    * FILE_UPLOAD_TOTAL_LIMIT: Total capacity limit for uploads (bytes). default: `Infinity`
-    * GCS_API_KEY_JSON_PATH: Path of the JSON file that contains [service account key to authenticate to GCP API](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
-    * GCS_BUCKET: Name of the GCS bucket
-    * GCS_UPLOAD_NAMESPACE: Directory name to create in the bucket
-    * MONGO_GRIDFS_TOTAL_LIMIT: Total capacity limit of MongoDB GridFS (bytes). default: `Infinity`
-        * MONGO_GRIDFS_TOTAL_LIMIT setting takes precedence over FILE_UPLOAD_TOTAL_LIMIT.
-* **Option to integrate with external systems**
-    * HACKMD_URI: URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server.
-        * **This server must load the GROWI agent. [Here's how to prepare it](https://docs.growi.org/guide/admin-cookbook/integrate-with-hackmd.html).**
-    * HACKMD_URI_FOR_SERVER: URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server from GROWI Express server. If not set, `HACKMD_URI` will be used.
-    * PLANTUML_URI: URI to connect to [PlantUML](http://plantuml.com/) server.
-    * BLOCKDIAG_URI: URI to connect to [blockdiag](http://http://blockdiag.com/) server.
-* **Option (Overwritable in admin page)**
-    * APP_SITE_URL: Site URL. e.g. `https://example.com`, `https://example.com:8080`
-    * LOCAL_STRATEGY_ENABLED: Enable or disable ID/Pass login
-    * LOCAL_STRATEGY_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: Prioritize env vars than values in DB for some ID/Pass login options
-    * SAML_ENABLED: Enable or disable SAML
-    * SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: Prioritize env vars than values in DB for some SAML options
-    * SAML_ENTRY_POINT: IdP entry point
-    * SAML_ISSUER: Issuer string to supply to IdP
-    * SAML_ATTR_MAPPING_ID: Attribute map for id
-    * SAML_ATTR_MAPPING_USERNAME: Attribute map for username
-    * SAML_ATTR_MAPPING_MAIL: Attribute map for email
-    * SAML_ATTR_MAPPING_FIRST_NAME: Attribute map for first name
-    * SAML_ATTR_MAPPING_LAST_NAME:  Attribute map for last name
-    * SAML_CERT: PEM-encoded X.509 signing certificate string to validate the response from IdP
-    * OAUTH_GOOGLE_CLIENT_ID: Google API client id for OAuth login.
-    * OAUTH_GOOGLE_CLIENT_SECRET: Google API client secret for OAuth login.
-    * OAUTH_GITHUB_CLIENT_ID: GitHub API client id for OAuth login.
-    * OAUTH_GITHUB_CLIENT_SECRET: GitHub API client secret for OAuth login.
-    * OAUTH_TWITTER_CONSUMER_KEY: Twitter consumer key(API key) for OAuth login.
-    * OAUTH_TWITTER_CONSUMER_SECRET: Twitter consumer secret(API secret) for OAuth login.
+|`NO_CDN`| If `true`, system doesn't use CDN, all resources will be downloaded from CDN when build client, and served by the GROWI Express server. default: `false`.|
+|`ELASTICSEARCH_URI`| URI to connect to Elasticearch.|
+|`REDIS_URI`| URI to connect to Redis (use it as a session store instead of MongoDB).|
+|`PASSWORD_SEED`| A password seed used by password hash generator.|
+|`SECRET_TOKEN`| A secret key for verifying the integrity of signed cookies.|
+|`SESSION_NAME`| The name of the session ID cookie to set in the response by Express. default: `connect.sid`|
+| `SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS`| If `true`, the system uses only the value of the environment variable as the value of the SAML option that can be set via the environment variable.|
+|`PUBLISH_OPEN_API`| Publish GROWI OpenAPI resources with [ReDoc](https://github.com/Rebilly/ReDoc). Visit `/api-docs`.|
+|`FORCE_WIKI_MODE`| Forces wiki mode. default: undefined|
+| |: `public`   Forces all pages to become public|
+| |: `private`  Forces all pages to become private|
+| |: `undefined`  Publicity will be configured by the admin security page settings|
+| `FORMAT_NODE_LOG`| If `false`, Output server log as JSON. defautl: `true` (Enabled only when `NODE_ENV=production`)|
+| **Option for file uploading** ||
+| `FILE_UPLOAD`| Attached files storage. default: `aws`|
+| |: `aws` Amazon Web Service S3 (needs AWS settings on Admin page)|
+| |: `gcs` Google Cloud Storage (needs settings with environment variables)|
+| |: `mongodb` MongoDB GridFS (Setting-less)|
+| |:  `local` Server's Local file system (Setting-less)|
+| |: `none`  Disable file uploading|
+| `FILE_UPLOAD_DISABLED`| If `true`, file uploading will be disabled. However, the files can be still viewed. Default: `false`|
+| `MAX_FILE_SIZE`| The maximum file size limit for uploads (bytes). default: `Infinity`|
+| `FILE_UPLOAD_TOTAL_LIMIT`| Total capacity limit for uploads (bytes). default: `Infinity`|
+| `GCS_API_KEY_JSON_PATH`| Path of the JSON file that contains [service account key to authenticate to GCP API](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)|
+| `GCS_BUCKET`| Name of the GCS bucket|
+| `GCS_UPLOAD_NAMESPACE`| Directory name to create in the bucket|
+| `MONGO_GRIDFS_TOTAL_LIMIT`| Total capacity limit of MongoDB GridFS (bytes). default: `Infinity`|
+|| MONGO_GRIDFS_TOTAL_LIMIT setting takes precedence over FILE_UPLOAD_TOTAL_LIMIT.|
+|**Option to integrate with external systems**||
+| `HACKMD_URI`| URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server.|
+|| This server must load the GROWI agent. [Here's how to prepare it](/en/admin-guide/admin-cookbook/integrate-with-hackmd.html).|
+| `HACKMD_URI_FOR_SERVER`| URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server from GROWI Express server. If not set, `HACKMD_URI` will be used.|
+| `PLANTUML_URI`| URI to connect to [PlantUML](http://plantuml.com/) server.|
+| `BLOCKDIAG_URI`| URI to connect to [blockdiag](http://http://blockdiag.com/) server.|
+|**Option (Overwritable in admin page)**||
+|  `APP_SITE_URL`| Site URL. e.g. `https://example.com`, `https://example.com:8080`|
+|  `LOCAL_STRATEGY_ENABLED`| Enable or disable ID/Pass login|
+|  `LOCAL_STRATEGY_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS`| Prioritize env vars than values in DB for some ID/Pass login options|
+|  `SAML_ENABLED`| Enable or disable SAML|
+|  `SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS`| Prioritize env vars than values in DB for some SAML options|
+|  `SAML_ENTRY_POINT`| IdP entry point|
+|  `SAML_ISSUER`| Issuer string to supply to IdP|
+|  `SAML_ATTR_MAPPING_ID`| Attribute map for id|
+|  `SAML_ATTR_MAPPING_USERNAME`| Attribute map for username|
+|  `SAML_ATTR_MAPPING_MAIL`| Attribute map for email|
+|  `SAML_ATTR_MAPPING_FIRST_NAME`| Attribute map for first name|
+|  `SAML_ATTR_MAPPING_LAST_NAME`|  Attribute map for last name|
+|  `SAML_CERT`| PEM-encoded X.509 signing certificate string to validate the response from IdP|
+|  `OAUTH_GOOGLE_CLIENT_ID`| Google API client id for OAuth login.|
+|  `OAUTH_GOOGLE_CLIENT_SECRET`| Google API client secret for OAuth login.|
+|  `OAUTH_GITHUB_CLIENT_ID`| GitHub API client id for OAuth login.|
+|  `OAUTH_GITHUB_CLIENT_SECRET`| GitHub API client secret for OAuth login.|
+|  `OAUTH_TWITTER_CONSUMER_KEY`| Twitter consumer key(API key) for OAuth login.|
+|  `OAUTH_TWITTER_CONSUMER_SECRET`| Twitter consumer secret(API secret) for OAuth login.|
 
 

--- a/docs/en/dev/tips/env-vars.md
+++ b/docs/en/dev/tips/env-vars.md
@@ -8,5 +8,70 @@
 
 |Enviroment Variable|Description|
 |---|---|
+| Required ||
+|`MONGO_URI`| URI to connect to MongoDB. |
+| Option ||
 |`PLUGIN_NAMES_TOBE_LOADED`|Specify plugins to load for development. See [Plugins](/en/dev/plugin/architecture.md).|
 |`DEV_HTTPS`|Start HTTPS express server using self-signed certificate in `resource/certs/localhost`.|
+|`NODE_ENV`| `production` OR `development`.|
+|`PORT`|Server port. default: `3000`.|
+|NO_CDN| If `true`, system doesn't use CDN, all resources will be downloaded from CDN when build client, and served by the GROWI Express server. default: `false`.|
+|ELASTICSEARCH_URI| URI to connect to Elasticearch.|
+|REDIS_URI| URI to connect to Redis (use it as a session store instead of MongoDB).|
+|PASSWORD_SEED| A password seed used by password hash generator.|
+|SECRET_TOKEN| A secret key for verifying the integrity of signed cookies.|
+|SESSION_NAME| The name of the session ID cookie to set in the response by Express. default: `connect.sid`|
+| SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS| If `true`, the system uses only the value of the environment variable as the value of the SAML option that can be set via the environment variable.|
+
+Environment Variables
+======================
+
+    * PUBLISH_OPEN_API: Publish GROWI OpenAPI resources with [ReDoc](https://github.com/Rebilly/ReDoc). Visit `/api-docs`.
+    * FORCE_WIKI_MODE: Forces wiki mode. default: undefined
+        * `public`  : Forces all pages to become public
+        * `private` : Forces all pages to become private
+        * undefined : Publicity will be configured by the admin security page settings
+    * FORMAT_NODE_LOG: If `false`, Output server log as JSON. defautl: `true` (Enabled only when `NODE_ENV=production`)
+* **Option for file uploading**
+    * FILE_UPLOAD: Attached files storage. default: `aws`
+        * `aws` : Amazon Web Service S3 (needs AWS settings on Admin page)
+        * `gcs` : Google Cloud Storage (needs settings with environment variables)
+        * `mongodb` : MongoDB GridFS (Setting-less)
+        * `local` : Server's Local file system (Setting-less)
+        * `none` : Disable file uploading
+    * FILE_UPLOAD_DISABLED: If `true`, file uploading will be disabled. However, the files can be still viewed. Default: `false`
+    * MAX_FILE_SIZE: The maximum file size limit for uploads (bytes). default: `Infinity`
+    * FILE_UPLOAD_TOTAL_LIMIT: Total capacity limit for uploads (bytes). default: `Infinity`
+    * GCS_API_KEY_JSON_PATH: Path of the JSON file that contains [service account key to authenticate to GCP API](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
+    * GCS_BUCKET: Name of the GCS bucket
+    * GCS_UPLOAD_NAMESPACE: Directory name to create in the bucket
+    * MONGO_GRIDFS_TOTAL_LIMIT: Total capacity limit of MongoDB GridFS (bytes). default: `Infinity`
+        * MONGO_GRIDFS_TOTAL_LIMIT setting takes precedence over FILE_UPLOAD_TOTAL_LIMIT.
+* **Option to integrate with external systems**
+    * HACKMD_URI: URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server.
+        * **This server must load the GROWI agent. [Here's how to prepare it](https://docs.growi.org/guide/admin-cookbook/integrate-with-hackmd.html).**
+    * HACKMD_URI_FOR_SERVER: URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server from GROWI Express server. If not set, `HACKMD_URI` will be used.
+    * PLANTUML_URI: URI to connect to [PlantUML](http://plantuml.com/) server.
+    * BLOCKDIAG_URI: URI to connect to [blockdiag](http://http://blockdiag.com/) server.
+* **Option (Overwritable in admin page)**
+    * APP_SITE_URL: Site URL. e.g. `https://example.com`, `https://example.com:8080`
+    * LOCAL_STRATEGY_ENABLED: Enable or disable ID/Pass login
+    * LOCAL_STRATEGY_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: Prioritize env vars than values in DB for some ID/Pass login options
+    * SAML_ENABLED: Enable or disable SAML
+    * SAML_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: Prioritize env vars than values in DB for some SAML options
+    * SAML_ENTRY_POINT: IdP entry point
+    * SAML_ISSUER: Issuer string to supply to IdP
+    * SAML_ATTR_MAPPING_ID: Attribute map for id
+    * SAML_ATTR_MAPPING_USERNAME: Attribute map for username
+    * SAML_ATTR_MAPPING_MAIL: Attribute map for email
+    * SAML_ATTR_MAPPING_FIRST_NAME: Attribute map for first name
+    * SAML_ATTR_MAPPING_LAST_NAME:  Attribute map for last name
+    * SAML_CERT: PEM-encoded X.509 signing certificate string to validate the response from IdP
+    * OAUTH_GOOGLE_CLIENT_ID: Google API client id for OAuth login.
+    * OAUTH_GOOGLE_CLIENT_SECRET: Google API client secret for OAuth login.
+    * OAUTH_GITHUB_CLIENT_ID: GitHub API client id for OAuth login.
+    * OAUTH_GITHUB_CLIENT_SECRET: GitHub API client secret for OAuth login.
+    * OAUTH_TWITTER_CONSUMER_KEY: Twitter consumer key(API key) for OAuth login.
+    * OAUTH_TWITTER_CONSUMER_SECRET: Twitter consumer secret(API secret) for OAuth login.
+
+


### PR DESCRIPTION
# GROWI README の内容を転記

https://github.com/weseek/growi

README の Environment Variables の部分を、
Docs の既存ページに追加しました。

[Environment Variables.pdf](https://github.com/weseek/growi-docs/files/3948920/Environment.Variables.pdf)
