### PR TITLE
develop-add-docker-compose

### DIFF
--- a/docs/en/dev/startup/launch.md
+++ b/docs/en/dev/startup/launch.md
@@ -10,7 +10,7 @@ git clone https://github.com/weseek/growi.git
 
 ### Confirm Versions
 
-See [Getting Started#Confirm Versions](dev-env.md#confirm-versions) 
+See [Getting Started#Confirm Versions](dev-env.md#confirm-versions)
 
 ### Set up Datastore for Development
 
@@ -18,6 +18,9 @@ Execute the following command in Docker environment.
 
 ::: tip
 For Windows, execute the command in the Linux VM set up in [Getting Started#Set up Dependent Middlewares](dev-env.md#set-up-dependent-middlewares).
+
+Install if there is no docker-compose command.  
+[docker docs Install Docker Compose](https://docs.docker.com/compose/install/)
 :::
 
 ``` bash

--- a/docs/ja/dev/startup/launch.md
+++ b/docs/ja/dev/startup/launch.md
@@ -18,6 +18,10 @@ Docker 利用可能な環境で以下を実行
 
 ::: tip
 Windows の場合は [開発環境の構築#開発環境の依存インフラの準備](dev-env.md#開発環境の依存インフラの準備) で準備した Linux マシンの中で実行する
+
+docker-compose コマンドがない場合はインストールしよう  
+[docker docs公式ページ　Install Docker Compose](https://docs.docker.com/compose/install/)
+
 :::
 
 ``` bash


### PR DESCRIPTION
# docker-compose コマンドインストールを促す文面を追記

![image](https://user-images.githubusercontent.com/42988650/76594408-65e26380-653c-11ea-936f-ec84f5c1f935.png)
![image](https://user-images.githubusercontent.com/42988650/76595781-e9518400-653f-11ea-8314-b3af23e3f913.png)

```
before
  config.vm.box = "envimation/ubuntu-xenial-docker"
after 
  config.vm.box = "chaifeng/ubuntu-18.04-docker-19.03"
```
box イメージの変更に伴い、ubuntu 内に docker-compose コマンドがインストールされていない状態となったため、追記。
