### PR TITLE
blockdiag url link error

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/en/admin-guide/admin-cookbook/env-vars.md
@@ -35,7 +35,7 @@
 | | This server must load the GROWI agent. [Here's how to prepare it](/en/admin-guide/admin-cookbook/integrate-with-hackmd.html). | |
 | `HACKMD_URI_FOR_SERVER` | URI to connect to [HackMD(CodiMD)](https://hackmd.io/) server from GROWI Express server. If not set, `HACKMD_URI` will be used. | |
 | `PLANTUML_URI` | URI to connect to [PlantUML](http://plantuml.com/) server. | |
-| `BLOCKDIAG_URI` | URI to connect to [blockdiag](http://http://blockdiag.com/) server. | |
+| `BLOCKDIAG_URI` | URI to connect to [blockdiag](http://blockdiag.com/) server. | |
 | `DRAWIO_URI` | URI to connect to [diagrams.net(draw.io)](https://www.diagrams.net/) server. | |
 | **Option (Overwritable in admin page)** | | |
 | `APP_SITE_URL` | Site URL. e.g. `https://example.com`, `https://example.com:8080` | |

--- a/docs/ja/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/ja/admin-guide/admin-cookbook/env-vars.md
@@ -34,7 +34,7 @@
 | | このサーバーは GROWI エージェントをロードする必要があります。 セットアップ方法は[こちら](/en/admin-guide/admin-cookbook/integrate-with-hackmd.html)。| |
 | `HACKMD_URI_FOR_SERVER` | GROWI Express サーバーが参照する [HackMD(CodiMD)](https://hackmd.io/) のURI。 未設定の場合は `HACKMD_URI` が使用されます。 | |
 | `PLANTUML_URI` | 接続する [PlantUML](http://plantuml.com/) サーバーの URI | |
-| `BLOCKDIAG_URI` | 接続する [blockdiag](http://http://blockdiag.com/) サーバーの URI | |
+| `BLOCKDIAG_URI` | 接続する [blockdiag](http://blockdiag.com/) サーバーの URI | |
 | `DRAWIO_URI` | 接続する [diagrams.net(draw.io)](https://www.diagrams.net/) サーバーの URI | |
 | **管理設定を上書きする環境変数** | | |
 | `APP_SITE_URL` | サイト URL (例: `https://example.com` 、 `https://example.com:8080`) | |


### PR DESCRIPTION
blockdiagへのリンクがリンクエラーになっていたので修正しました
ブランチルールなどわからなかったため、とりあえず master 宛にしています