### PR TITLE
Imprv/gw6347 header adjustment

### DIFF
--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -244,7 +244,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
   1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
 
-    ![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
+  ![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
 
   1. **Create New Command** をクリックします。
   <!-- TODO: GW-6349 [Custom bot with proxy] 画像の変更 by GW-6349 -->

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -122,12 +122,12 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
   1. **Create New Command** をクリックします。
     ![slash-commands-create-new-command](../../../.vuepress/public/assets/images/slash-commands-create-new-command.png)
 
-    - Command に /growi と入力してください。
-    - Request URL には、`https://example.com/_api/v3/slack-bot/commands` と入力してください
-    - Short Description も入力必須のため、適当なご説明を入力してください。
-    - Usage Hint に関しては任意なので、適宜入力してください。
-    - Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
-    - 入力が完了したら、**Save** をクリックしてください。
+      - Command に /growi と入力してください。
+      - Request URL には、`https://example.com/_api/v3/slack-bot/commands` と入力してください
+      - Short Description も入力必須のため、適当なご説明を入力してください。
+      - Usage Hint に関しては任意なので、適宜入力してください。
+      - Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
+      - 入力が完了したら、**Save** をクリックしてください。
 
   ![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
 

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -33,6 +33,11 @@ Custom bot with proxy は Slack bot を作成し、proxy サーバーを立ち�
 
 Incoming Webhook も Slack 連携を行う手段の一つですが、GROWI bot とは異なり、Slack への通知に特化しています。チャットからの全文検索など GROWI bot にある機能の多くは使うことができませんが、その分簡単にセットアップできます。詳しくは[通知の種類/設定方法](/ja/admin-guide/management-cookbook/external-notification.html#通知の種類-設定方法)をご覧ください。
 
+
+## Official bot 設定
+
+(TBD)
+
 ## Custom bot without proxy 設定
 
 Custom bot without proxy を Slack のワークスペースに導入するには、Slack アプリを作成・編集する必要があります。手順は以下の通りです。
@@ -169,9 +174,6 @@ Signing Secret と Bot User OAuth Token の設定を行う前に、作成した 
 
 環境変数 `SLACK_SIGNING_SECRET` と `SLACK_BOT_TOKEN` に確認した値を代入してください。
 
-## Official bot 設定
-
-(TBD)
 
 ## Custom bot with proxy 設定
 
@@ -270,9 +272,25 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 ### テストを実行する
 <!-- TODO: GW-6328 [Custom bot with proxy]「テストを実行する」の記述(ja) -->
 
-### Incoming webhook のセットアップ
 
-<!-- TODO: GW-5372 「Slack/Mattermost への通知」の内容を適切なタイトルの下に移動させる -->
+## GROWI bot でできること
+
+### ワークスペース内の全文検索
+
+1. /growi search [keyword(s)] を入力すると検索結果が表示されます。
+
+   - 例: /growi search example
+     ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
+   - 検索結果
+     ![slack-bot-full-text-search-display-result](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result.png)
+   - **Next** ボタンをクリックすると、次の検索結果を表示します。
+     ![slack-bot-full-text-search-click-next](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-next.png)
+   - **Share** ボタンをクリックすると、チャンネル内に共有されます。
+     ![slack-bot-full-text-search-click-share](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-share.png)
+
+<!-- ### 複数ワークスペースの横断検索 (TBD) -->
+
+<!-- ### Slack ログの記録 (TBD) -->
 
 ## Incoming webhook 設定
 
@@ -296,22 +314,3 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 この方法で通知を行うことを GROWI では **User Trigger Notification** といいます。
 
 User Trigger Notification の設定方法は[こちら](../management-cookbook/external-notification.html#user-trigger-notification-設定)を参照してください。
-
-## Slack bot でできること
-
-### ワークスペース内の全文検索
-
-1. /growi search [keyword(s)] を入力すると検索結果が表示されます。
-
-   - 例: /growi search example
-     ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
-   - 検索結果
-     ![slack-bot-full-text-search-display-result](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result.png)
-   - **Next** ボタンをクリックすると、次の検索結果を表示します。
-     ![slack-bot-full-text-search-click-next](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-next.png)
-   - **Share** ボタンをクリックすると、チャンネル内に共有されます。
-     ![slack-bot-full-text-search-click-share](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-share.png)
-
-<!-- ### 複数ワークスペースの横断検索 (TBD) -->
-
-<!-- ### Slack ログの記録 (TBD) -->

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -95,17 +95,17 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 - **Interactivity & Shortcuts** の Request URL を設定する
 
   1. 作成した Slack App の **Features** から **Interactivity Shortcuts** をクリックします。
-     ![slack-bot-interactivity-shortcuts-introduction](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-introduction.png)
+    ![slack-bot-interactivity-shortcuts-introduction](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-introduction.png)
 
   1. **Interactivity** 右側にあるボタンを On にします。
-     ![slack-bot-interactivity-shortcuts-enable-button](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-enable-button.png)
+    ![slack-bot-interactivity-shortcuts-enable-button](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-enable-button.png)
 
   1. Request URL を以下のように入力してください。
 
-      - https:// 連携させたい GROWI のドメイン名 /\_api/v3/slack-bot/interactions
-        - 例 `https://example.com/_api/v3/slack-bot/interactions`
+  - https:// 連携させたい GROWI のドメイン名 /\_api/v3/slack-bot/interactions
+  - 例 `https://example.com/_api/v3/slack-bot/interactions`
 
-     ![slack-bot-interactivity-shortcuts-creation](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-creation.png)
+  ![slack-bot-interactivity-shortcuts-creation](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-creation.png)
 
   1. 入力が完了したら、**Save Changes** をクリックしてください。
 
@@ -113,7 +113,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
 1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
 
-![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
+  ![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
 
 2. **Create New Command** をクリックします。
 

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -184,22 +184,20 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
 Custom bot with proxy を Slack のワークスペースに導入するには、Slack アプリを作成・編集する必要があります。手順は以下の通りです。
 
-### Slack app を作成する前に
+### Custom bot with proxy を作成する前に
 
-1. `packages/slackbot-proxy` の配下に 新規ファイル`.env.development.local`を作成します。
-2. 1で作成したファイルに任意の環境変数`SERVER_URI`を入力してください。
+  1. `packages/slackbot-proxy` の配下に 新規ファイル`.env.development.local`を作成します。
+  1. 1で作成したファイルに任意の環境変数`SERVER_URI`を入力してください。
 
-例: `SERVER_URI=http://localhost:8080`
+  例: `SERVER_URI=http://localhost:8080`
 
-3. GROWI 本体サーバーとプロキシ用サーバー(`slackbot-proxy`)の両方を立ち上げてください。
+  1. GROWI 本体サーバーとプロキシ用サーバー(`slackbot-proxy`)の両方を立ち上げてください。  
+    プロキシ用サーバーは`yarn`, `yarn dev`で起動することができます。
 
-- プロキシ用サーバーは`yarn`, `yarn dev`で起動することができます。
+  1. 管理画面の Slack 連携 にて Custom bot with proxy を選択してください。
+  <!-- TODO: GW-6349 [Custom bot with proxy] 画像の挿入 -->
 
-### Bot type の選択
-
-管理画面の Slack 連携 にて Custom bot with proxy を選択してください。
-
-### Slack app を作成する
+### Custom bot with proxy を作成する
 
 1. Slack API の[アプリページ](https://api.slack.com/apps)に移動し、「Create New App」をクリックします。
 
@@ -212,7 +210,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
    ![slack-custom-bot2](../../../.vuepress/public/assets/images/slack-custom-bot2.png)
 
-### スコープを設定する
+### Custom bot with proxy のスコープを設定する
 
 1. 作成した Slack App の **Features** から **OAuth & Permissions** をクリックします。
   ![slack-bot-oauth-and-permissions-introduction-no-check](../../../.vuepress/public/assets/images/slack-bot-oauth-and-permissions-introduction-no-check.png)
@@ -222,7 +220,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
   以下のように表示されたら、スコープの設定は完了です。
   ![slack-bot-scope-selected](../../../.vuepress/public/assets/images/slack-bot-scope-selected.png)
 
-### 各 Request URL を設定する
+### Request URL 設定
 
 #### Interactivity & Shortcuts
 
@@ -237,12 +235,12 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 - https:// 連携させたい PROXY のドメイン名 /slack/interactions
   - 例 `https://example.com/slack/interactions`
 
-    <!-- TODO: GW-6349 [Custom bot with proxy] 画像の変更 by GW-6349 -->
-    ![slack-bot-interactivity-shortcuts-creation](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-creation.png)
+      <!-- TODO: GW-6349 [Custom bot with proxy] 画像の変更 by GW-6349 -->
+      ![slack-bot-interactivity-shortcuts-creation](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-creation.png)
 
-  1. 入力が完了したら、**Save Changes** をクリックしてください。
+    1. 入力が完了したら、**Save Changes** をクリックしてください。
 
-#### スラッシュコマンドの作成
+#### Slash Commandss
 
   1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
 
@@ -252,12 +250,12 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
   <!-- TODO: GW-6349 [Custom bot with proxy] 画像の変更 by GW-6349 -->
   ![slash-commands-create-new-command](../../../.vuepress/public/assets/images/slash-commands-create-new-command.png)
 
-- Command に /growi と入力してください。
-- Request URL には、`https://example.com/slack/commands` と入力してください
-- Short Description も入力必須のため、適当なご説明を入力してください。
-- Usage Hint に関しては任意なので、適宜入力してください。
-- Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
-- 入力が完了したら、**Save** をクリックしてください。
+      - Command に /growi と入力してください。
+      - Request URL には、`https://example.com/slack/commands` と入力してください
+      - Short Description も入力必須のため、適当なご説明を入力してください。
+      - Usage Hint に関しては任意なので、適宜入力してください。
+      - Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
+      - 入力が完了したら、**Save** をクリックしてください。
 
   ![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
 
@@ -268,7 +266,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 ### Manage Distribution を設定する
 <!-- TODO: GW-6329 [Custom bot with proxy]「Manage Distribution を設定する」を記述する(ja)) -->
 
-### Bot を Slack のワークスペースへインストールする
+### Custom bot with proxy を Slack のワークスペースへインストールする
 <!-- TODO: GW-6326 [Custom bot with proxy] 「Bot を Slack のワークスペースへインストールする」の記述(ja) -->
 
 ### アクセストークンの発行 / GROWI Official Bot Proxyサービスへの登録

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -33,21 +33,19 @@ Custom bot with proxy は Slack bot を作成し、proxy サーバーを立ち�
 
 Incoming Webhook も Slack 連携を行う手段の一つですが、GROWI bot とは異なり、Slack への通知に特化しています。チャットからの全文検索など GROWI bot にある機能の多くは使うことができませんが、その分簡単にセットアップできます。詳しくは[通知の種類/設定方法](/ja/admin-guide/management-cookbook/external-notification.html#通知の種類-設定方法)をご覧ください。
 
-## 各種 Bot のセットアッップ
-
-### Custom bot without proxy 設定
+## Custom bot without proxy 設定
 
 Custom bot without proxy を Slack のワークスペースに導入するには、Slack アプリを作成・編集する必要があります。手順は以下の通りです。
 
-#### Slack app を作成する前に
+### Slack app を作成する前に
 
 GROWI 本体サーバーを立ち上げてください。後述する Event Subscription の応答に必要となります。
 
-#### Bot type の選択
+### Bot type の選択
 
 管理画面の Slack 連携 にて Custom bot without proxy を選択してください。
 
-#### Slack app を作成する
+### Slack app を作成する
 
 1. Slack API の[アプリページ](https://api.slack.com/apps)に移動し、「Create New App」をクリックします。
 
@@ -60,7 +58,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
    ![slack-custom-bot2](../../../.vuepress/public/assets/images/slack-custom-bot2.png)
 
-#### スコープを設定する
+### スコープを設定する
 
 1. 作成した Slack App の **Features** から **OAuth & Permissions** をクリックします。
   ![slack-bot-oauth-and-permissions-introduction-no-check](../../../.vuepress/public/assets/images/slack-bot-oauth-and-permissions-introduction-no-check.png)
@@ -70,7 +68,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
   以下のように表示されたら、スコープの設定は完了です。  
   ![slack-bot-scope-selected](../../../.vuepress/public/assets/images/slack-bot-scope-selected.png)
 
-#### 各 Request URL を設定する
+### 各 Request URL を設定する
 
 - **Event Subscriptions** の Request URL を設定する
 
@@ -106,7 +104,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
   1. 入力が完了したら、**Save Changes** をクリックしてください。
 
-#### スラッシュコマンドの作成
+### スラッシュコマンドの作成
 
 1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
 
@@ -125,7 +123,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
 ![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
 
-#### Bot を Slack のワークスペースへインストールする
+### Bot を Slack のワークスペースへインストールする
 
 1. 作成した Slack App の **Settings** から **Basic Information** をクリックします。
 1. **Install your app** をクリックします。
@@ -140,7 +138,7 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
    ![slack-bot-install-to-workspace-joined-bot](../../../.vuepress/public/assets/images/slack-bot-install-to-workspace-joined-bot.png)
    ![slack-bot-install-your-app-introduction-to-channel](../../../.vuepress/public/assets/images/slack-bot-install-your-app-introduction-to-channel.png)
 
-#### Signing Secret と Bot User OAuth Token の設定
+### Signing Secret と Bot User OAuth Token の設定
 
 Signing Secret と Bot User OAuth Token の設定を行う前に、作成した Bot でそれぞれの値を確認します。
 
@@ -171,15 +169,15 @@ Signing Secret と Bot User OAuth Token の設定を行う前に、作成した 
 
 環境変数 `SLACK_SIGNING_SECRET` と `SLACK_BOT_TOKEN` に確認した値を代入してください。
 
-### Official bot 設定
+## Official bot 設定
 
 (TBD)
 
-### Custom bot with proxy 設定
+## Custom bot with proxy 設定
 
 Custom bot with proxy を Slack のワークスペースに導入するには、Slack アプリを作成・編集する必要があります。手順は以下の通りです。
 
-#### Slack app を作成する前に
+### Slack app を作成する前に
 
 1. `packages/slackbot-proxy` の配下に 新規ファイル`.env.development.local`を作成します。
 2. 1で作成したファイルに任意の環境変数`SERVER_URI`を入力してください。
@@ -190,11 +188,11 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
 - プロキシ用サーバーは`yarn`, `yarn dev`で起動することができます。
 
-#### Bot type の選択
+### Bot type の選択
 
 管理画面の Slack 連携 にて Custom bot with proxy を選択してください。
 
-##### Slack app を作成する
+### Slack app を作成する
 
 1. Slack API の[アプリページ](https://api.slack.com/apps)に移動し、「Create New App」をクリックします。
 
@@ -207,7 +205,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
    ![slack-custom-bot2](../../../.vuepress/public/assets/images/slack-custom-bot2.png)
 
-#### スコープを設定する
+### スコープを設定する
 
 1. 作成した Slack App の **Features** から **OAuth & Permissions** をクリックします。
   ![slack-bot-oauth-and-permissions-introduction-no-check](../../../.vuepress/public/assets/images/slack-bot-oauth-and-permissions-introduction-no-check.png)
@@ -217,9 +215,9 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
   以下のように表示されたら、スコープの設定は完了です。
   ![slack-bot-scope-selected](../../../.vuepress/public/assets/images/slack-bot-scope-selected.png)
 
-#### 各 Request URL を設定する
+### 各 Request URL を設定する
 
-##### Interactivity & Shortcuts
+#### Interactivity & Shortcuts
 
   1. 作成した Slack App の **Features** から **Interactivity Shortcuts** をクリックします。
     ![slack-bot-interactivity-shortcuts-introduction](../../../.vuepress/public/assets/images/slack-bot-interactivity-shortcuts-introduction.png)
@@ -237,7 +235,7 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
   1. 入力が完了したら、**Save Changes** をクリックしてください。
 
-##### スラッシュコマンドの作成
+#### スラッシュコマンドの作成
 
   1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
 
@@ -256,27 +254,27 @@ Custom bot with proxy を Slack のワークスペースに導入するには、
 
   ![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
 
-##### OAuth & Permissions
+#### OAuth & Permissions
 <!-- TODO: GW-6353 [Custom bot with proxy]Redirect URLの設定方法を記述する -->
 
 
-3. Manage Distribution を設定する
+### Manage Distribution を設定する
 <!-- TODO: GW-6329 [Custom bot with proxy]「Manage Distribution を設定する」を記述する(ja)) -->
 
-#### Bot を Slack のワークスペースへインストールする
+### Bot を Slack のワークスペースへインストールする
 <!-- TODO: GW-6326 [Custom bot with proxy] 「Bot を Slack のワークスペースへインストールする」の記述(ja) -->
 
-#### アクセストークンの発行 / GROWI Official Bot Proxyサービスへの登録
+### アクセストークンの発行 / GROWI Official Bot Proxyサービスへの登録
 <!-- TODO: GW-6327 [Custom bot with proxy]「アクセストークンの発行 / GROWI Official Bot Proxyサービスへの登録」の記述(ja) -->
 
-#### テストを実行する
+### テストを実行する
 <!-- TODO: GW-6328 [Custom bot with proxy]「テストを実行する」の記述(ja) -->
 
 ### Incoming webhook のセットアップ
 
 <!-- TODO: GW-5372 「Slack/Mattermost への通知」の内容を適切なタイトルの下に移動させる -->
 
-### Incoming webhook 設定
+## Incoming webhook 設定
 
 <!-- TODO: GW-5372 「Slack/Mattermost への通知」の内容を適切なタイトルの下に移動させる -->
 

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -6,32 +6,37 @@ GROWI では、 Slack 連携の方法として、1. GROWI bot と 2. Incoming We
 
 ### 1. GROWI bot
 
-GROWI bot は GROWI 開発チーム が開発した Slack App の一つです。任意の Slack ワークスペースにインストールすることで、GROWI からの通知だけでなくチャットからの全文検索実行や会話まとめなど様々な機能を利用することができるようになります。
+GROWI bot は GROWI 開発チーム が開発した Slack App の一つです。任意の Slack ワークスペースにインストールすることで、
+GROWI からの通知だけでなくチャットからの全文検索実行や会話まとめなど様々な機能を利用することができるようになります。
 
 #### Official bot (推奨)
 
 【概念図】
 ![diagram-for-official-bot](../../../.vuepress/public/assets/images/slack-bot-outline-official.png)
 
-Official GROWI bot は GROWI 開発チーム が無償で提供・運用している GROWI bot です。[slack app directory](https://wsgrowi.slack.com/apps) で公開されており、どなたでも利用できます。
+Official GROWI bot は GROWI 開発チーム が無償で提供・運用している GROWI bot です。
+[slack app directory](https://wsgrowi.slack.com/apps) で公開されており、どなたでも利用できます。
 
 #### Custom bot without proxy
 
 【概念図】
 ![diagram-for-custom-bot-without-bot](../../../.vuepress/public/assets/images/slack-bot-outline-custom-without-proxy.png)
 
-Custom bot without proxy は Slack bot を作成し、お使いの GROWI と紐付けを行うことで、Slack から GROWI の 機能の一部を使用することができます。
+Custom bot without proxy は Slack bot を作成し、お使いの GROWI と紐付けを行うことで、
+Slack から GROWI の 機能の一部を使用することができます。
 
 #### Custom bot with proxy
 
 【概念図】
 ![diagram-for-custom-bot-with-proxy](../../../.vuepress/public/assets/images/slack-bot-outline-custom-with-proxy.png)
 
-Custom bot with proxy は Slack bot を作成し、proxy サーバーを立ち上げ・設定することで、Official bot と同様の手順で GROWI の機能の一部を使用することができます。
+Custom bot with proxy は Slack bot を作成し、proxy サーバーを立ち上げ・設定することで、
+Official bot と同様の手順で GROWI の機能の一部を使用することができます。
 
 ### 2. Incoming Webhook
 
-Incoming Webhook も Slack 連携を行う手段の一つですが、GROWI bot とは異なり、Slack への通知に特化しています。チャットからの全文検索など GROWI bot にある機能の多くは使うことができませんが、その分簡単にセットアップできます。詳しくは[通知の種類/設定方法](/ja/admin-guide/management-cookbook/external-notification.html#通知の種類-設定方法)をご覧ください。
+Incoming Webhook も Slack 連携を行う手段の一つですが、GROWI bot とは異なり、Slack への通知に特化しています。
+チャットからの全文検索など GROWI bot にある機能の多くは使うことができませんが、その分簡単にセットアップできます。詳しくは[通知の種類/設定方法](/ja/admin-guide/management-cookbook/external-notification.html#通知の種類-設定方法)をご覧ください。
 
 
 ## Official bot 設定
@@ -111,37 +116,35 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
 ### スラッシュコマンドの作成
 
-1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
+  1. 作成した Slack App の **Features** から **Slash Commands** をクリックします。
+    ![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
 
-  ![slash-commands-introduction](../../../.vuepress/public/assets/images/slash-commands-introduction.png)
+  1. **Create New Command** をクリックします。
+    ![slash-commands-create-new-command](../../../.vuepress/public/assets/images/slash-commands-create-new-command.png)
 
-2. **Create New Command** をクリックします。
+    - Command に /growi と入力してください。
+    - Request URL には、`https://example.com/_api/v3/slack-bot/commands` と入力してください
+    - Short Description も入力必須のため、適当なご説明を入力してください。
+    - Usage Hint に関しては任意なので、適宜入力してください。
+    - Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
+    - 入力が完了したら、**Save** をクリックしてください。
 
-![slash-commands-create-new-command](../../../.vuepress/public/assets/images/slash-commands-create-new-command.png)
-
-- Command に /growi と入力してください。
-- Request URL には、`https://example.com/_api/v3/slack-bot/commands` と入力してください
-- Short Description も入力必須のため、適当なご説明を入力してください。
-- Usage Hint に関しては任意なので、適宜入力してください。
-- Escape channels, users, and links sent to your app に関しては任意なので、適宜入力してください。
-- 入力が完了したら、**Save** をクリックしてください。
-
-![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
+  ![slash-commands-create](../../../.vuepress/public/assets/images/slash-commands-create.png)
 
 ### Bot を Slack のワークスペースへインストールする
 
-1. 作成した Slack App の **Settings** から **Basic Information** をクリックします。
-1. **Install your app** をクリックします。
-   ![slack-bot-install-your-app-introduction](../../../.vuepress/public/assets/images/slack-bot-install-your-app-introduction.png)
-1. **Install to Workspace** をクリックします。
-   ![slack-bot-install-to-workspace](../../../.vuepress/public/assets/images/slack-bot-install-to-workspace.png)
-1. 遷移先の画面にて、**Allow**をクリックします。
-   ![slack-bot-install-your-app-transition-destination](../../../.vuepress/public/assets/images/slack-bot-install-your-app-transition-destination.png)
-1. Install your app の右側に 緑色のチェックがつけばワークスペースへのインストール完了です。
-   ![slack-bot-install-your-app-complete](../../../.vuepress/public/assets/images/slack-bot-install-your-app-complete.png)
-1. GROWI bot を使いたいチャンネルに @example を使用して招待します。
-   ![slack-bot-install-to-workspace-joined-bot](../../../.vuepress/public/assets/images/slack-bot-install-to-workspace-joined-bot.png)
-   ![slack-bot-install-your-app-introduction-to-channel](../../../.vuepress/public/assets/images/slack-bot-install-your-app-introduction-to-channel.png)
+  1. 作成した Slack App の **Settings** から **Basic Information** をクリックします。
+  1. **Install your app** をクリックします。
+    ![slack-bot-install-your-app-introduction](../../../.vuepress/public/assets/images/slack-bot-install-your-app-introduction.png)
+  1. **Install to Workspace** をクリックします。
+    ![slack-bot-install-to-workspace](../../../.vuepress/public/assets/images/slack-bot-install-to-workspace.png)
+  1. 遷移先の画面にて、**Allow**をクリックします。
+    ![slack-bot-install-your-app-transition-destination](../../../.vuepress/public/assets/images/slack-bot-install-your-app-transition-destination.png)
+  1. Install your app の右側に 緑色のチェックがつけばワークスペースへのインストール完了です。
+    ![slack-bot-install-your-app-complete](../../../.vuepress/public/assets/images/slack-bot-install-your-app-complete.png)
+  1. GROWI bot を使いたいチャンネルに @example を使用して招待します。
+    ![slack-bot-install-to-workspace-joined-bot](../../../.vuepress/public/assets/images/slack-bot-install-to-workspace-joined-bot.png)
+    ![slack-bot-install-your-app-introduction-to-channel](../../../.vuepress/public/assets/images/slack-bot-install-your-app-introduction-to-channel.png)
 
 ### Signing Secret と Bot User OAuth Token の設定
 

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -148,9 +148,9 @@ GROWI 本体サーバーを立ち上げてください。後述する Event Subs
 
 ### Signing Secret と Bot User OAuth Token の設定
 
-Signing Secret と Bot User OAuth Token の設定を行う前に、作成した Bot でそれぞれの値を確認します。
+  Signing Secret と Bot User OAuth Token の設定を行う前に、作成した Bot でそれぞれの値を確認します。
 
-**Signing Secret の確認方法**
+#### Signing Secret の確認方法
 
 1. 作成した Slack App の **Settings** から **Basic Information** をクリックします。
    ![slack-bot-basic-information](../../../.vuepress/public/assets/images/slack-bot-basic-information.png)
@@ -158,24 +158,26 @@ Signing Secret と Bot User OAuth Token の設定を行う前に、作成した 
 1. App Credentials の **Signing Secret** の **show** ボタンを押して確認します。
    ![slack-bot-signing-secret](../../../.vuepress/public/assets/images/slack-bot-signing-secret.png)
 
-**Bot User OAuth Token の確認方法**
+#### Bot User OAuth Token の確認方法
 
 1. 作成した Slack App の **Settings** から **OAuth and Permissions** をクリックします。
    ![slack-bot-oauth-and-permissions-introduction](../../../.vuepress/public/assets/images/slack-bot-oauth-and-permissions-introduction.png)
+
 1. **OAuth Tokens for Your Team** の **Bot User Oauth Token** から確認します。
    ![slack-bot-oauth-and-permissions](../../../.vuepress/public/assets/images/slack-bot-oauth-and-permissions.png)
 
-確認した Signing Secret と Bot User OAuth Token は 1. 管理画面で入力して設定する方法 と 2. 環境変数で設定する方法の 2 種類の方法があります。管理画面で直接入力する方が容易です。また、環境変数と管理画面の両方に入力した場合は、管理画面で入力した値が優先されるので、管理画面での入力をおすすめします。
+確認した **Signing Secret** と **Bot User OAuth Token** は 1. 管理画面で入力して設定する方法 と 2. 環境変数で設定する方法の
+ 2 種類の方法があります。管理画面で直接入力する方が容易です。
+また、環境変数と管理画面の両方に入力した場合は、管理画面で入力した値が優先されるので、管理画面での入力をおすすめします。
 
 1. 管理画面で直接入力する方法
+  管理画面の Slack 連携をクリックし、**Signing Secret** と **Bot User OAuth Token** を入力して
+   **Update** ボタンをクリックします。
+  ![slack-integration](../../../.vuepress/public/assets/images/slack-integration-introduction.png)
 
-管理画面の Slack 連携をクリックし、Signing Secret と Bot User OAuth Token を入力して **Update** をクリックします。
+1. 環境変数で設定する方法
 
-![slack-integration](../../../.vuepress/public/assets/images/slack-integration-introduction.png)
-
-2. 環境変数で設定する方法
-
-環境変数 `SLACK_SIGNING_SECRET` と `SLACK_BOT_TOKEN` に確認した値を代入してください。
+  環境変数 `SLACK_SIGNING_SECRET` と `SLACK_BOT_TOKEN` に確認した値を代入してください。
 
 
 ## Custom bot with proxy 設定


### PR DESCRIPTION
## Task
GW-6347 見出しの整理
- 全体の画像はファイルサイズが大きすぎて添付不可
- インデント & 文字の長さによるwarningが大量にでていたので修正
- headerの位置も修正

## Before
<img width="327" alt="Screen Shot 2021-06-18 at 13 21 40" src="https://user-images.githubusercontent.com/59536731/122505859-23111480-d038-11eb-882b-3cf52d0c6562.png">

## After
<img width="368" alt="Screen Shot 2021-06-18 at 13 18 06" src="https://user-images.githubusercontent.com/59536731/122505665-c57cc800-d037-11eb-8e06-7de243fc29ce.png">
