### PR TITLE
Imprv/multi growi search into full text search

### DIFF
--- a/docs/en/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/en/admin-guide/management-cookbook/slack-integration.md
@@ -501,7 +501,7 @@ For details on how to configure User Trigger Notification, please refer to here.
    - Click the **Share** button to share it within the channel.
      ![slack-bot-full-text-search-click-share](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-share.png)
 
-1. If you have registered your Slack workspace in multiple GROWIs, you can search across multiple GROWI App(s). (* This is only available when the Bot type is Official bot or Custom bot with proxy.)
+1. If you have registered your Slack workspace in multiple GROWIs, you can search across multiple GROWI App(s). (This is only available when the Bot type is Official bot or Custom bot with proxy.)
 
     - e.g.: `/growi search example`
         ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
@@ -511,12 +511,12 @@ For details on how to configure User Trigger Notification, please refer to here.
 
 ### Check the connected GROWI
 
-By typing `/growi status`, you can see the GROWI App(s) that is connected to the Slack workspace.(* This is only available when the Bot type is Official bot or Custom bot with proxy.)
+By typing `/growi status`, you can see the GROWI App(s) that is connected to the Slack workspace. (This is only available when the Bot type is Official bot or Custom bot with proxy.)
 ![slack-bot-growi-status](../../../.vuepress/public/assets/images/slack-bot-growi-status.png)
 
 ### Unregister the Slack workspace from the GROWI App(s)
 
-  1. Please input `/growi unregister [URL1 of the GROWI App to be unregistered] [URL2 of the GROWI App to be unregistered]...`, then the modal as bellow will be displayed.
+  1. Please input `/growi unregister [URL1 of the GROWI App to be unregistered] [URL2 of the GROWI App to be unregistered]...`, then the modal as bellow will be displayed. (This is only available when the Bot type is Official bot or Custom bot with proxy.)
        - e.g.: `growi unregister http://example.com http://growi.jp`  
        ![slack-bot-unregister-input-eg](../../../.vuepress/public/assets/images/slack-bot-unregister-input-eg.png)
 

--- a/docs/en/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/en/admin-guide/management-cookbook/slack-integration.md
@@ -501,21 +501,18 @@ For details on how to configure User Trigger Notification, please refer to here.
    - Click the **Share** button to share it within the channel.
      ![slack-bot-full-text-search-click-share](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-share.png)
 
+1. If you have registered your Slack workspace in multiple GROWIs, you can search across multiple GROWI App(s). (* This is only available when the Bot type is Official bot or Custom bot with proxy.)
+
+    - e.g.: `/growi search example`
+        ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
+    - Search results.
+        <!-- TODO 6581 -->
+        ![slack-bot-search-multi-growi](../../../.vuepress/public/assets/images/slack-bot-search-multi-growi.png)
+
 ### Check the connected GROWI
 
-By typing `/growi status`, you can see the GROWI App(s) that is connected to the Slack workspace.
+By typing `/growi status`, you can see the GROWI App(s) that is connected to the Slack workspace.(* This is only available when the Bot type is Official bot or Custom bot with proxy.)
 ![slack-bot-growi-status](../../../.vuepress/public/assets/images/slack-bot-growi-status.png)
-
-### Search pages from multi GROWI
-
-By registering your Slack workspace with multi GROWI Apps, you will be able to search across them.
-Please search for `/growi search [keyword(s)]` in your workspace.
-
-- e.g.: `/growi search example`
-     ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
-- Search results.
-     <!-- 画像は後で差し替える。ワークスペースが記載されていない。 -->
-     ![slack-bot-search-multi-growi](../../../.vuepress/public/assets/images/slack-bot-search-multi-growi.png)
 
 ### Unregister the Slack workspace from the GROWI App(s)
 
@@ -529,6 +526,4 @@ Please search for `/growi search [keyword(s)]` in your workspace.
   1. Click on **Submit** button.
   1. If the following is displayed, the unregister the Slack workspace is completed.
     ![slack-bot-unregister-completed](../../../.vuepress/public/assets/images/slack-bot-unregister-completed.png)
-
-<!-- ### 複数 GROWI の横断検索 (TBD) -->
 

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -461,7 +461,7 @@
 
 ### Slack ワークスペースと GROWI App との連携を解除する
 
-  1. `/growi unregister [連携解除したい GROWI App の URL1] [連携解除したい GROWI App の URL2] ...` と入力するとモーダルが表示されます。
+  1. `/growi unregister [連携解除したい GROWI App の URL1] [連携解除したい GROWI App の URL2] ...` と入力するとモーダルが表示されます。(※ Bot type が Official bot と Custom bot with proxy の場合のみ使えます。)
 
      - 入力例: `growi unregister http://example.com http://growi.jp`
      ![slack-bot-unregister-input-eg](../../../.vuepress/public/assets/images/slack-bot-unregister-input-eg.png)

--- a/docs/ja/admin-guide/management-cookbook/slack-integration.md
+++ b/docs/ja/admin-guide/management-cookbook/slack-integration.md
@@ -446,23 +446,18 @@
    - **Share** ボタンをクリックすると、チャンネル内に共有されます。
      ![slack-bot-full-text-search-click-share](../../../.vuepress/public/assets/images/slack-bot-full-text-search-click-share.png)
 
+1. Slack ワークスペースを複数の GROWI に登録している場合、複数の GROWI から横断検索することができます。(※ Bot type が Official bot と Custom bot with proxy の場合のみ使えます。)
+
+    - 例: `/growi search example`
+        ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
+    - 検索結果
+        <!-- TODO 6581 -->
+        ![slack-bot-search-multi-growi](../../../.vuepress/public/assets/images/slack-bot-search-multi-growi.png)
+
 ### 接続中の GROWI を確認する
 
 `/growi status` と入力することで、Slack ワークスペースと連携している GROWI を確認することができます。(※ Bot type が Official bot と Custom bot with proxy の場合のみ使えます。)
 ![slack-bot-growi-status](../../../.vuepress/public/assets/images/slack-bot-growi-status.png)
-
-### 複数 の GROWI からページを横断検索する
-
-Slack ワークスペースを 複数の GROWI に登録することによって、横断検索することが可能になります。
-お使いのワークスペースで `/growi search [キーワード]` と検索してください。
-
-- 例: `/growi search example`
-     ![slack-bot-full-text-search-display-result-command](../../../.vuepress/public/assets/images/slack-bot-full-text-search-display-result-command.png)
-- 検索結果
-     <!-- 画像は後で差し替える。ワークスペースが記載されていない。 -->
-     ![slack-bot-search-multi-growi](../../../.vuepress/public/assets/images/slack-bot-search-multi-growi.png)
-
-
 
 ### Slack ワークスペースと GROWI App との連携を解除する
 


### PR DESCRIPTION
## 概要
- 複数 GROWI 横断検索を Full text search 内に移行しました。
- また proxy を使わないとできないことに対しての注釈が抜けているところがあったので追加しています。
### イメージ
<img width="839" alt="Screen Shot 2021-06-29 at 15 51 01" src="https://user-images.githubusercontent.com/57100766/123750879-0c997180-d8f2-11eb-8386-a63275a6271f.png">

<img width="797" alt="Screen Shot 2021-06-29 at 15 48 04" src="https://user-images.githubusercontent.com/57100766/123750861-073c2700-d8f2-11eb-812f-cc9a124aeb46.png">
