### PR TITLE
HackMD integrationのトラブルシューティングにCookie名衝突時の対処を追加

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/integrate-with-hackmd.md
+++ b/docs/en/admin-guide/admin-cookbook/integrate-with-hackmd.md
@@ -111,5 +111,8 @@ Set up will follow these instructions [README.md](https://github.com/weseek/grow
     - content inserted into head.ejs and foot.ejs are correct
     - the URL from the src attribute of the script tag inserted into the source code of HackMD/CodiMD can be accessed successfully (can load the CSS and JavaScript).
 
+### Error when pressing "Update", and GROWI session expires ("/login" appears when you move to another page)
 
+- The session cookie names `connect.sid` are conflicting between GROWI and HackMD/CodiMD
+  - Set the environment variable `SESSION_NAME` in GROWI to change the cookie name
 

--- a/docs/ja/admin-guide/admin-cookbook/integrate-with-hackmd.md
+++ b/docs/ja/admin-guide/admin-cookbook/integrate-with-hackmd.md
@@ -99,4 +99,8 @@
   - head.ejs, foot.ejs に記述した内容が正しいこと
   - HackMD/CodiMD のソース中に挿入された script タグの src のURLに正常にアクセスできる(css, JavaScript をロードできる)こと
 
+### 編集後の「更新」ボタン押下時にエラー、加えて GROWI のセッションが切れる(ページ遷移するとログイン画面に戻される)
+
+- GROWI と HackMD/CodiMD のセッション情報を保持するCookie名が `connect.sid` で被っていることが原因です
+  - GROWI の環境変数 `SESSION_NAME` を変更してください
 


### PR DESCRIPTION
* 既存のHackMD/CodiMDと連携する場合に必要と思いましたので追加しました。
  - 最新のCodiMD(2.4.1)では`sessionName`が変更不可となっていましたので、GROWI側のCookie名を変えるような説明としました。