### PR TITLE
NCHAN_URI環境変数の修正

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/loadbalance.md
+++ b/docs/en/admin-guide/admin-cookbook/loadbalance.md
@@ -12,7 +12,7 @@
 
 ```
 S2SMSG_PUBSUB_SERVER_TYPE=nchan
-NCHAN_URI=http://nchan
+NCHAN_URI=ws://nchan
 ```
 
 ### More info

--- a/docs/ja/admin-guide/admin-cookbook/loadbalance.md
+++ b/docs/ja/admin-guide/admin-cookbook/loadbalance.md
@@ -12,7 +12,7 @@
 
 ```
 S2SMSG_PUBSUB_SERVER_TYPE=nchan
-NCHAN_URI=http://nchan
+NCHAN_URI=ws://nchan
 ```
 
 ### 詳細設定


### PR DESCRIPTION
## 概要
- #313 
- NCHAN_URIのプロトコルは`http`ではなく、`ws`が正しいと思われる