### PR TITLE
feat: Ignore unnecessary markdown during the build process

### DIFF
--- a/config-growi-org.js
+++ b/config-growi-org.js
@@ -8,6 +8,13 @@ module.exports = {
   // https://github.com/vuejs/vuepress/issues/2392#issuecomment-651903508
   temp: path.resolve(__dirname, 'temp'),
 
+  // Markdown of build target
+  // TODO: Ignore Help-growi-cloud content
+  patterns: [
+    '**/*.md',
+    '**/*.vue',
+  ],
+
   plugins: [
     'tabs',
     [

--- a/config-help-growi-cloud.js
+++ b/config-help-growi-cloud.js
@@ -7,6 +7,16 @@ module.exports = {
    * Ref：https://v1.vuepress.vuejs.org/config/#description
    */
 
+  // Markdown of build target
+  patterns: [
+    '**/*.md',
+    '**/*.vue',
+    // Folders to ignore at build: https://github.com/vuejs/vuepress/issues/1558
+    '!(ja|en)/admin-guide/(admin-cookbook|downgrading|getting-started|migration-guide)/**',
+    '!(ja|en)/api/**',
+    '!(ja|en)/dev/**',
+  ],
+
   /**
    * Extra tags to be injected to the page HTML `<head>`
    *
@@ -64,5 +74,4 @@ module.exports = {
     '@vuepress/plugin-back-to-top',
     '@vuepress/plugin-medium-zoom',
   ],
-
 };


### PR DESCRIPTION
## Task
[#118149](https://redmine.weseek.co.jp/issues/118149) [Docs 組み替え]  新/旧 docs をそれぞれビルドできる
└ [#118857](https://redmine.weseek.co.jp/issues/118857) 不要なマークダウンファイルをビルド結果に含めないようにする