### PR TITLE
#121127 fix links

### DIFF
--- a/docs/en/guide/tips/hierarchical.md
+++ b/docs/en/guide/tips/hierarchical.md
@@ -27,11 +27,11 @@ The options you can set include:
 
 | Parameter name    | Default value    |  Explanation   | Additional details |
 | --- | --- | --- | --- |
-|  num   |  not set(< growi-plugin-lsx 4.0.0), 50(>= growi-plugin-lsx 4.0.0)   | Specify the number of pages in the hierarchy.| [num option details](#num-option) |
-|  depth   |  not set   | Specify the maximum hierarchy depth to display.| [depth option details](#depth-option) |
-|  sort   |  path   | Specify the sort order of the hierarchy. | [sort option details](#sort-option) |
-|  reverse   |  false   | Reverse the order of the hierarchy.| [reverse option details](#reverse-option) |
-|  filter   |  not set   | Filter the hierarchy according to some parameters. | [filter option details](#filter-option) |
+|  num   |  not set(< growi-plugin-lsx 4.0.0), 50(>= growi-plugin-lsx 4.0.0)   | Specify the number of pages in the hierarchy.| [num option details](./hierarchical.html#num) |
+|  depth   |  not set   | Specify the maximum hierarchy depth to display.| [depth option details](./hierarchical.html#depth) |
+|  sort   |  path   | Specify the sort order of the hierarchy. | [sort option details](./hierarchical.html#sort) |
+|  reverse   |  false   | Reverse the order of the hierarchy.| [reverse option details](./hierarchical.html#reverse) |
+|  filter   |  not set   | Filter the hierarchy according to some parameters. | [filter option details](./hierarchical.html#filter) |
 
 Additional details are as follows.
 

--- a/docs/ja/guide/tips/hierarchical.md
+++ b/docs/ja/guide/tips/hierarchical.md
@@ -37,11 +37,11 @@ lsx にはページ指定だけでなく、複数のオプションの設定も�
 
 | パラメータ    | デフォルト値    |  説明   | 詳細 |
 | --- | --- | --- | --- |
-|  num   |  未設定(< growi-plugin-lsx 4.0.0), 50(>= growi-plugin-lsx 4.0.0)   | ページ一覧の出力数を指定。| [numオプション詳細](#num-オプション) |
-|  depth   |  未設定   | 階層を指定してページ一覧を出力。| [depthオプション詳細](#depth-オプション) |
-|  sort   |  path   | ページ一覧の並び順を指定。| [sortオプション詳細](#sort-オプション) |
-|  reverse   |  false   | ページ一覧の並び順を逆にする。| [reverseオプション詳細](#reverse-オプション) |
-|  filter   |  未設定   | ページ一覧に出力する内容をフィルタする。 | [filterオプション詳細](#filter-オプション) |
+|  num   |  未設定(< growi-plugin-lsx 4.0.0), 50(>= growi-plugin-lsx 4.0.0)   | ページ一覧の出力数を指定。| [numオプション詳細](./hierarchical.html#num-オプション) |
+|  depth   |  未設定   | 階層を指定してページ一覧を出力。| [depthオプション詳細](./hierarchical.html#depth-オプション) |
+|  sort   |  path   | ページ一覧の並び順を指定。| [sortオプション詳細](./hierarchical.html#sort-オプション) |
+|  reverse   |  false   | ページ一覧の並び順を逆にする。| [reverseオプション詳細](./hierarchical.html#reverse-オプション) |
+|  filter   |  未設定   | ページ一覧に出力する内容をフィルタする。 | [filterオプション詳細](./hierarchical.html#filter-オプション) |
 
 
 ### num オプション

--- a/docs/ja/guide/tips/page_linker.md
+++ b/docs/ja/guide/tips/page_linker.md
@@ -73,11 +73,15 @@ GROWI では、各ページへのリンクの書き方として、以下の2つ�
 
 ### 例4: 外部サイト
 
+<!--
+機能していないため、一時的に非公開
+
 #### Markdown
 
 ```markdown
 [[Google>https://www.google.co.jp]]
 ```
+-->
 
 #### HTML
 

--- a/docs/ja/guide/tips/page_linker.md
+++ b/docs/ja/guide/tips/page_linker.md
@@ -73,15 +73,11 @@ GROWI では、各ページへのリンクの書き方として、以下の2つ�
 
 ### 例4: 外部サイト
 
-<!--
-機能していないため、一時的に非公開
-
 #### Markdown
 
 ```markdown
 [[Google>https://www.google.co.jp]]
 ```
--->
 
 #### HTML
 


### PR DESCRIPTION
以下の Docs 管理シート内に記載された87 行目、89行目の修正の修正
- https://docs.google.com/spreadsheets/d/126DbZ59OmPA_Kj1M4SUX3smEU_nfX95I8XBxqCpnvpU/edit#gid=0
- https://docs.growi.org/ja/guide/tips/hierarchical.html
  - リンク切れの修正 
- https://docs.growi.org/ja/guide/tips/page_linker.html
  - 機能していない記法をコメントアウト