### PR TITLE
feat: Separating markdown files included during build into 'help' and 'docs'

### DIFF
--- a/docs/.vuepress/config-docs-growi-org.js
+++ b/docs/.vuepress/config-docs-growi-org.js
@@ -9,11 +9,13 @@ module.exports = {
   // https://github.com/vuejs/vuepress/issues/2392#issuecomment-651903508
   temp: path.resolve(__dirname, 'temp'),
 
-  // Markdown of build target
-  // TODO: Ignore Help-growi-cloud content
   patterns: [
-    '**/*.md',
     '**/*.vue',
+    // Markdown of build target
+    '**/*.md',
+    // Folders to ignore at build: https://github.com/vuejs/vuepress/issues/1558
+    '!**/index.md',
+    '!(ja|en)/cloud/**',
   ],
 
   plugins: [

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -35,11 +35,13 @@ module.exports = {
     editLinkText: '',
     lastUpdated: false,
     links: {
-      '/help/ja': [
+      'ja': [
         {
           title: 'チュートリアル',
           key: 'tutorial',
           children: [
+            '/ja/guide/getting-started/five_minutes.md',
+            '/ja/guide/getting-started/markdown.md',
             '/ja/guide/tutorial/create_page.md',
             '/ja/guide/tutorial/duplicate_page.md',
             '/ja/guide/tutorial/delete_page.md',
@@ -84,8 +86,137 @@ module.exports = {
             '/ja/guide/features/questionnaire.md',
           ]
         },
+        {
+          title: 'GROWI 管理者のクックブック',
+          key: 'management-cookbook',
+          children: [
+            '/ja/admin-guide/management-cookbook/app-settings.md',
+            '/ja/admin-guide/management-cookbook/line-breaks.md',
+            '/ja/admin-guide/management-cookbook/security.md',
+            '/ja/admin-guide/management-cookbook/user-management.md',
+            '/ja/admin-guide/management-cookbook/group.md',
+            '/ja/admin-guide/management-cookbook/ldap.md',
+            '/ja/admin-guide/management-cookbook/slack-integration/official-bot-settings.md',
+            '/ja/admin-guide/management-cookbook/slack-integration/custom-bot-without-proxy-settings.md',
+            '/ja/admin-guide/management-cookbook/slack-integration/custom-bot-with-proxy-settings.md',
+            '/ja/admin-guide/management-cookbook/active-directory.md',
+            '/ja/admin-guide/management-cookbook/google-analytics.md',
+            '/ja/admin-guide/management-cookbook/external-notification.md',
+            '/ja/admin-guide/management-cookbook/import.md',
+            '/ja/admin-guide/management-cookbook/export.md',
+            '/ja/admin-guide/management-cookbook/g2g-transfer.md',
+            '/ja/admin-guide/management-cookbook/setup-search-system.md',
+            '/ja/admin-guide/management-cookbook/audit-log.md',
+          ]
+        },
+        {
+          'title': 'アップグレード',
+          'key': 'upgrading',
+          'children': [
+            '/ja/admin-guide/upgrading/61x.md',
+            '/ja/admin-guide/upgrading/60x.md',
+            '/ja/admin-guide/upgrading/51x.md',
+            '/ja/admin-guide/upgrading/50x.md',
+            '/ja/admin-guide/upgrading/45x.md',
+            '/ja/admin-guide/upgrading/44x.md',
+            '/ja/admin-guide/upgrading/43x.md',
+            '/ja/admin-guide/upgrading/42x.md',
+            '/ja/admin-guide/upgrading/41x.md',
+            '/ja/admin-guide/upgrading/40x.md',
+          ]
+        }
       ],
-    }
+      'en': [
+        {
+          title: 'Tutorial',
+          key: 'tutorial',
+          children: [
+            '/en/guide/getting-started/five_minutes.md',
+            '/en/guide/getting-started/markdown.md',
+            '/en/guide/tutorial/create_page.md',
+            '/en/guide/tutorial/duplicate_page.md',
+            '/en/guide/tutorial/delete_page.md',
+          ],
+        },
+        {
+          title: 'Tips',
+          key: 'tips',
+          children: [
+            '/en/guide/tips/hierarchical.md',
+            '/en/guide/tips/include_html.md',
+            '/en/guide/tips/checkbox.md',
+            '/en/guide/tips/page_linker.md',
+            '/en/guide/tips/footnote.md',
+          ],
+        },
+        {
+          title: 'Feature introduction',
+          key: 'feature-introduction',
+          children: [
+            '/en/guide/features/page_layout.md',
+            '/en/guide/features/copy_to_clipboard.md',
+            '/en/guide/features/table.md',
+            '/en/guide/features/bookmark.md',
+            '/en/guide/features/page_operation.md',
+            '/en/guide/features/page_deletion_collectively.md',
+            '/en/guide/features/emoji.md',
+            '/en/guide/features/history.md',
+            '/en/guide/features/authority.md',
+            '/en/guide/features/bootstrap.md',
+            '/en/guide/features/uml_diagrams.md',
+            '/en/guide/features/drawio.md',
+            '/en/guide/features/mermaid.md',
+            '/en/guide/features/search.md',
+            '/en/guide/features/tag.md',
+            '/en/guide/features/template.md',
+            '/en/guide/features/hackmd.md',
+            '/en/guide/features/in-app-notification.md',
+            '/en/guide/features/slack_integration.md',
+            '/en/guide/features/file_upload',
+            '/en/guide/features/questionnaire.md',
+          ]
+        },
+        {
+          title: 'Management cookbook',
+          key: 'management-cookbook',
+          children: [
+            '/en/admin-guide/management-cookbook/app-settings.md',
+            '/en/admin-guide/management-cookbook/line-breaks.md',
+            '/en/admin-guide/management-cookbook/security.md',
+            '/en/admin-guide/management-cookbook/user-management.md',
+            '/en/admin-guide/management-cookbook/group.md',
+            '/en/admin-guide/management-cookbook/aws-s3-bucket-setting.md',
+            '/en/admin-guide/management-cookbook/ldap.md',
+            '/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.md',
+            '/en/admin-guide/management-cookbook/slack-integration/custom-bot-without-proxy-settings.md',
+            '/en/admin-guide/management-cookbook/slack-integration/custom-bot-with-proxy-settings.md',
+            '/en/admin-guide/management-cookbook/active-directory.md',
+            '/en/admin-guide/management-cookbook/google-analytics.md',
+            '/en/admin-guide/management-cookbook/external-notification.md',
+            '/en/admin-guide/management-cookbook/import.md',
+            '/en/admin-guide/management-cookbook/export.md',
+            '/en/admin-guide/management-cookbook/setup-search-system.md',
+            '/en/admin-guide/management-cookbook/audit-log.md',
+          ]
+        },
+        {
+          'title': 'Upgrading',
+          'key': 'upgrading',
+          'children': [
+            '/en/admin-guide/upgrading/61x.md',
+            '/en/admin-guide/upgrading/60x.md',
+            '/en/admin-guide/upgrading/51x.md',
+            '/en/admin-guide/upgrading/50x.md',
+            '/en/admin-guide/upgrading/45x.md',
+            '/en/admin-guide/upgrading/44x.md',
+            '/en/admin-guide/upgrading/43x.md',
+            '/en/admin-guide/upgrading/42x.md',
+            '/en/admin-guide/upgrading/41x.md',
+            '/en/admin-guide/upgrading/40x.md',
+          ]
+        }
+      ]
+    },
   },
 
   plugins: [

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -222,7 +222,7 @@ module.exports = {
   plugins: [
     [Canonical , {
       canonicalBase: 'https://docs.growi.org',
-      excludePathPatterns: ['(ja|en)\/cloud\/.*'],
+      excludePathPatterns: ['(ja|en)\/$', '(ja|en)\/cloud\/.*'],
     }],
     '@vuepress/plugin-back-to-top',
     '@vuepress/plugin-medium-zoom',

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -15,14 +15,16 @@ module.exports = {
     },
   },
 
-  // Markdown of build target
   patterns: [
-    '**/*.md',
     '**/*.vue',
+    // Markdown of build target
+    '(ja|en)/index.md',
+    '(ja|en)/cloud/**',
+    '(ja|en)/guide/**',
+    '(ja|en)/admin-guide/(management-cookbook|upgrading)/**',
     // Folders to ignore at build: https://github.com/vuejs/vuepress/issues/1558
-    '!(ja|en)/admin-guide/(admin-cookbook|downgrading|getting-started|migration-guide)/**',
-    '!(ja|en)/api/**',
-    '!(ja|en)/dev/**',
+    '!**/README.md',
+    '!(ja|en)/admin-guide/upgrading/(34x|35x|36x||37x|38x).md'
   ],
 
   themeConfig: {

--- a/docs/.vuepress/help-growi-cloud-theme/components/PageLinks.vue
+++ b/docs/.vuepress/help-growi-cloud-theme/components/PageLinks.vue
@@ -5,8 +5,8 @@
       <hr class="mt-3 mb-4">
     </div>
 
-    <div class="row mb-5">
-      <div class="col-md-6" v-for="pageItem in this.pageItems" :key="pageItem.key" >
+    <div class="row">
+      <div class="col-md-6 mb-5" v-for="pageItem in this.pageItems" :key="pageItem.key" >
         <h4 class="fw-bold mb-4">{{ pageItem.title }}</h4>
         <ul class="gc-page-ul" v-for="child in pageItem.children" :key="child.key" >
           <li><a class="gc-page-link" :href="child.regularPath" >{{ child.title }}</a></li>

--- a/docs/.vuepress/help-growi-cloud-theme/components/Top.vue
+++ b/docs/.vuepress/help-growi-cloud-theme/components/Top.vue
@@ -2,7 +2,7 @@
    <div class="container mt-4">
 
     <!-- TODO: i18n categoryName -->
-    <PageLinks categoryName="Docs" :pageItems="getPageItems(['tutorial', 'tips', 'feature-introduction'])" />
+    <PageLinks categoryName="Docs" :pageItems="getPageItems(['tutorial', 'tips', 'feature-introduction', 'management-cookbook', 'upgrading'])" />
 
       <!-- ▼ 共通, よくある質問 ▼  -->
       <div class="mb-5">
@@ -209,8 +209,7 @@ export default {
   },
 
   beforeMount() {
-    // TODO: i18n
-    this.topPageItems = resolveTopPageItems(this.$site, 'ja');
+    this.topPageItems = resolveTopPageItems(this.$site, this.$lang);
   },
 
   methods: {

--- a/docs/.vuepress/utils/index.js
+++ b/docs/.vuepress/utils/index.js
@@ -127,7 +127,7 @@ function resolveItem (item, pages, base, groupDepth = 1) {
  */
 export function resolveTopPageItems (site, lang) {
   const { pages, themeConfig } = site
-  const links = themeConfig.links[`/help/${lang}`]
+  const links = themeConfig.links[lang];
 
   return links != null
     ? links.map(item => resolveItem(item, pages, links))

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -5,6 +5,7 @@ actionText: Get Started
 actionLink: /guide/
 footer: © 2018 WESEEK, Inc.
 ---
+<!-- for docs-growi-org root-->
 
 <div align="center">
   <a href="https://github.com/weseek/growi/" target="_blank"><img src="https://img.shields.io/github/stars/weseek/growi.svg?style=social&label=Stars"></a>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,5 @@
+---
+home: true
+---
+<!-- for help-growi-cloud root-->
+<!-- https://github.com/vuejs/vuepress/issues/944 -->

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -5,6 +5,7 @@ actionText: ガイドを見る
 actionLink: /ja/guide/
 footer: © 2018 WESEEK, Inc.
 ---
+<!-- for docs-growi-org root-->
 
 <div align="center">
   <a href="https://github.com/weseek/growi/" target="_blank"><img src="https://img.shields.io/github/stars/weseek/growi.svg?style=social&label=Stars"></a>

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,5 @@
+---
+home: true
+---
+<!-- for help-growi-cloud root-->
+<!-- https://github.com/vuejs/vuepress/issues/944 -->


### PR DESCRIPTION
[#124390](https://redmine.weseek.co.jp/issues/124390) [docs-reorganization] build 時に含めるマークダウンファイルを help と docs で分けることができる
└ [#124392](https://redmine.weseek.co.jp/issues/124392) 実装