### PR TITLE
feat: Create Docker image to host the static files generated by building the VuePress app on Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 #  Build Stage
 #
-FROM node:16-slim AS builder
+FROM node:16-alpine AS builder
 
 WORKDIR /growi-docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 #  Build Stage
 #
-FROM node:16-alpine AS builder
+FROM node:16-slim AS builder
 
 WORKDIR /growi-docs
 
@@ -17,7 +17,7 @@ RUN yarn help-growi-cloud:build
 #
 # Production Stage
 #
-FROM nginx:alpine
+FROM nginx:latest
 
 COPY --from=builder /growi-docs/docs/.vuepress/dist /usr/share/nginx/html/help
 COPY --from=builder /growi-docs/docs/.vuepress/dist/assets/images /usr/share/nginx/html/assets/images

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 ###  This Docker file processes Multi Stage Build for help-growi-cloud
 ###
 
-##
-# Stage 1
+#
+#  Build Stage
 #
 FROM node:16-slim AS builder
 
@@ -14,9 +14,15 @@ RUN yarn
 RUN yarn help-growi-cloud:build
 
 
-##
-# Stage 2
 #
-FROM node:16-slim
+# Production Stage
+#
+FROM nginx:alpine
 
-COPY --from=builder /growi-docs/docs/.vuepress/dist .
+COPY --from=builder /growi-docs/docs/.vuepress/dist /usr/share/nginx/html/help
+COPY --from=builder /growi-docs/docs/.vuepress/dist/assets/images /usr/share/nginx/html/assets/images
+RUN rm -rf /usr/share/nginx/html/help/assets/images
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
-FROM node:16.13.0-alpine AS builder
+###
+###  This Docker file processes Multi Stage Build for help-growi-cloud
+###
+
+##
+# Stage 1
+#
+FROM node:16-slim AS builder
 
 WORKDIR /growi-docs
 
 COPY . .
-
 RUN yarn
 RUN yarn help-growi-cloud:build
+
+
+##
+# Stage 2
+#
+FROM node:16-slim
+
+COPY --from=builder /growi-docs/docs/.vuepress/dist .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16.13.0-alpine AS builder
+
+WORKDIR /growi-docs
+
+COPY . .
+
+RUN yarn
+RUN yarn help-growi-cloud:build

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -5,7 +5,7 @@ const localeDataEn = require('./localeDataEn');
 
 module.exports = {
   title: 'GROWI.Cloud Help',
-  base: '/help',
+  base: '/help/',
 
   locales: {
     '/en/': {


### PR DESCRIPTION
## Task
[#125219](https://redmine.weseek.co.jp/issues/125219) Dockerfile の作成

## memo
以下のコマンドで、http:localhost:8000/help/ja にビルドされた静的ファイルが nginx 上にホストされる

```
$ docker build -t help-growi-cloud .
$ docker run -p 8080:80 help-growi-cloud
```