### PR TITLE
feat: Adopt Google Tag Manager

### DIFF
--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -238,7 +238,6 @@ module.exports = {
   ],
 
   head: [
-    ['link', { rel: 'stylesheet', href: 'https://use.fontawesome.com/releases/v6.2.0/css/all.css'}],
     ['script', {}, `
       (function(w,d,s,l,i){
         w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -247,6 +246,7 @@ module.exports = {
         j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-MMNSMCF');
-    `]
+    `],
+    ['link', { rel: 'stylesheet', href: 'https://use.fontawesome.com/releases/v6.2.0/css/all.css'}]
   ],
 };

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -239,5 +239,14 @@ module.exports = {
 
   head: [
     ['link', { rel: 'stylesheet', href: 'https://use.fontawesome.com/releases/v6.2.0/css/all.css'}],
+    ['script', {}, `
+      (function(w,d,s,l,i){
+        w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});
+        var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-MMNSMCF');
+    `]
   ],
 };

--- a/docs/.vuepress/help-growi-cloud-theme/Layout.vue
+++ b/docs/.vuepress/help-growi-cloud-theme/Layout.vue
@@ -27,6 +27,10 @@ import SearchBox from '@theme/components/SearchBox'
 export default {
   components: { Header, Footer, Top, Article, SearchBox },
 
+  beforeMount() {
+    this.prependGoogleTagManagerScript();
+  },
+
   data() {
     return {
       isTopPage: false
@@ -34,6 +38,12 @@ export default {
   },
 
   methods: {
+    prependGoogleTagManagerScript() {
+      const recaptchaScript = document.createElement('noscript')
+      recaptchaScript.innerHTML = '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MMNSMCF" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+      document.body.prepend(recaptchaScript)
+    },
+
     validateTopPageURL() {
       return location.pathname.match('^\/help\/(ja|en)\/?$') != null;
     }


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/125274

- `/blog` と同じタグを header と body に埋め込む

```
head 内に埋め込むコード
<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'[https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f)](https://www.googletagmanager.com/gtm.js?id=%27+i+dl;f.parentNode.insertBefore(j,f));
})(window,document,'script','dataLayer','GTM-MMNSMCF');</script>
<!-- End Google Tag Manager -->

body の直後に埋め込むコード
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MMNSMCF"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
```

参考記事: https://www.rendezvous-tokyo.net/tech/2022/10/22/vuepress-gtm/

## Screenshot
### header のなるべく上のほう
![image](https://github.com/weseek/growi-docs/assets/68407388/908eb4a8-a5fa-46af-8e9c-712f569907dd)

### `<body>` の直後
![image](https://github.com/weseek/growi-docs/assets/68407388/dadf88b6-c31d-4d18-82fe-a4af546bb038)
 



