### PR TITLE
feat: Add vuepress-plugin-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "vue-tabs-component": "^1.5.0",
     "vuepress": "^1.8.2",
     "vuepress-jsdoc": "^3.0.0",
+    "vuepress-plugin-container": "^2.1.5",
     "vuepress-plugin-tabs": "^0.3.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14387,6 +14387,14 @@ vuepress-plugin-container@^2.0.2:
   dependencies:
     markdown-it-container "^2.0.0"
 
+vuepress-plugin-container@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/vuepress-plugin-container/-/vuepress-plugin-container-2.1.5.tgz#37fff05662fedbd63ffd3a5463b2592c7a7f3133"
+  integrity sha512-TQrDX/v+WHOihj3jpilVnjXu9RcTm6m8tzljNJwYhxnJUW0WWQ0hFLcDTqTBwgKIFdEiSxVOmYE+bJX/sq46MA==
+  dependencies:
+    "@vuepress/shared-utils" "^1.2.0"
+    markdown-it-container "^2.0.0"
+
 vuepress-plugin-dehydrate@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/vuepress-plugin-dehydrate/-/vuepress-plugin-dehydrate-1.1.5.tgz#c29f08b85f337d3bc7c0ba09fe58cd9ed2f6e6c1"


### PR DESCRIPTION
## Task
[#118147](https://redmine.weseek.co.jp/issues/118147) [docs-reorganization] XD 通りにヘルプページを表示できる
└ [#124311](https://redmine.weseek.co.jp/issues/124311) マークダウンのCustomBlock 実装

## Memo
CustomBlock が復活 
<img width="790" alt="ScreenShot 2023-06-23 0 57 48" src="https://github.com/weseek/growi-docs/assets/34241526/c107dc97-b413-4987-9ab1-ada5527fc52a">

