### PR TITLE
128268 setup vuepress-html-redirect

### DIFF
--- a/docs/.vuepress/config-docs-growi-org.js
+++ b/docs/.vuepress/config-docs-growi-org.js
@@ -61,7 +61,12 @@ module.exports = {
           '(ja|en)\/admin-guide\/(admin-cookbook|downgrading|getting-started|migration-guide)\/.*',
         ]
       }
-    ]
+    ],
+    [
+      '@vuepress/html-redirect', {
+        countdown: 0
+      }
+    ],
   ],
 
   markdown: {

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -403,6 +403,9 @@ module.exports = {
         '/en/': 'DANGER'
       }
     }],
+    ['@vuepress/html-redirect', {
+      countdown: 0
+    }],
   ],
 
   markdown: {

--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -1,0 +1,4 @@
+/ja/guide/tutorial/create_page.html /ja/guide/features/create_page.html
+/en/guide/tutorial/create_page.html /en/guide/features/create_page.html
+/help/ja/guide/tutorial/create_page.html /help/ja/guide/features/create_page.html
+/help/en/guide/tutorial/create_page.html /help/en/guide/features/create_page.html

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@popperjs/core": "^2.11.8",
     "@vuepress/plugin-google-analytics": "^1.8.2",
+    "@vuepress/plugin-html-redirect": "^0.2.1",
     "@vuepress/plugin-search": "^1.9.9",
     "babel-eslint": "^10.0.1",
     "bootstrap": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,6 +1697,11 @@
   resolved "https://registry.yarnpkg.com/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.8.2.tgz#96cf65f1f0ecbb3bcf6b0d10089dafe2aea875bc"
   integrity sha512-BMFayLzT2BvXmnhM9mDHw0UPU7J0pH1X9gQA4HmZxOf7f3+atK5eJGsc1Ia/+1FTG2ESvhFLUU/CC3h5arjEJw==
 
+"@vuepress/plugin-html-redirect@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@vuepress/plugin-html-redirect/-/plugin-html-redirect-0.2.1.tgz#d31f727b417e19123e50f45921301febbe776cb5"
+  integrity sha512-QRDBzYrr6V8yoCAz2fQd+CNHup4kBebUdpRSxU/4wTFiAMe9Ex4qUw4o1VmCsw4nokLB32qQko0eovI/6PAJlg==
+
 "@vuepress/plugin-last-updated@1.8.2":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@vuepress/plugin-last-updated/-/plugin-last-updated-1.8.2.tgz#7ce689f8d5050cf0213949bc2e5aa879c09ff4b1"


### PR DESCRIPTION
# 注意
- https://github.com/weseek/growi-docs/pull/410 が終わったらマージすること
# 概要
- チュートリアルページの廃止に伴い、削除対象のチュートリアルページのURLにリダイレクト設定をする。
- リダイレクト先は、新しく作成したユーザーガイドのページにする(guide/tutorial/create_page.html → guide/features/create_page.html)

# タスク
- https://redmine.weseek.co.jp/issues/128275