### PR TITLE
imprv: Change link to plugin site from en page

### DIFF
--- a/docs/en/admin-guide/management-cookbook/plugins.md
+++ b/docs/en/admin-guide/management-cookbook/plugins.md
@@ -2,7 +2,7 @@
 
 You can customize GROWI by Plugins.
 
-Please check [GROWI plugin site](https://growi.org/plugins) for publicly available plugins.
+Please check [GROWI plugin site](https://growi.org/plugins/en) for publicly available plugins.
 
 [[toc]]
 

--- a/docs/en/admin-guide/management-cookbook/plugins.md
+++ b/docs/en/admin-guide/management-cookbook/plugins.md
@@ -8,7 +8,7 @@ Please check [GROWI plugin site](https://growi.org/plugins) for publicly availab
 
 ## How to install plugins
 
-1. Go to [GROWI plugin site](https://growi.org/plugins).
+1. Go to [GROWI plugin site](https://growi.org/plugins/en).
 
 2. Copy the URL of the GitHub repository that you want to install.
 

--- a/docs/en/admin-guide/upgrading/60x.md
+++ b/docs/en/admin-guide/upgrading/60x.md
@@ -24,7 +24,7 @@ There is nothing special to note when downgrading to v5.x series.
 ### [Beta] Plugin Mechanism
 
 Added new plugin mechanism.  
-Now you can see published plugins on [the official site](https://growi.org/plugins).
+Now you can see published plugins on [the official site](https://growi.org/plugins/en).
 
 As of 2023.01, some features are not implemented.
 


### PR DESCRIPTION
# やったこと
docsの/en 内のAdmin Guideで GROWI plugin siteへのリンクを変更し、plugins/en/へアクセスできるようにしました。

# Task
https://redmine.weseek.co.jp/issues/134957