### PR TITLE
Add shortcut keys page to docs and help sidebars

### DIFF
--- a/docs/.vuepress/config-docs-growi-org.js
+++ b/docs/.vuepress/config-docs-growi-org.js
@@ -169,7 +169,8 @@ module.exports = {
                 '/en/guide/features/ai-knowledge-assistant.md',
                 '/en/guide/features/ai-editor-assistant.md',
                 '/en/guide/features/mcp-server',
-                '/en/guide/features/ai-tools.md'
+                '/en/guide/features/ai-tools.md',
+                '/en/guide/features/shortcut-keys.md'
               ]
             },
             {
@@ -441,7 +442,8 @@ module.exports = {
                 '/ja/guide/features/ai-knowledge-assistant.md',
                 '/ja/guide/features/ai-editor-assistant.md',
                 '/ja/guide/features/mcp-server.md',
-                '/ja/guide/features/ai-tools.md'
+                '/ja/guide/features/ai-tools.md',
+                '/ja/guide/features/shortcut-keys.md'
               ]
             },
             {

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -175,7 +175,8 @@ module.exports = {
             '/ja/guide/features/ai-knowledge-assistant.md',
             '/ja/guide/features/ai-editor-assistant.md',
             '/ja/guide/features/mcp-server',
-            '/ja/guide/features/ai-tools.md'
+            '/ja/guide/features/ai-tools.md',
+            '/ja/guide/features/shortcut-keys.md'
           ]
         },
         {
@@ -343,6 +344,7 @@ module.exports = {
             '/en/guide/features/ai-editor-assistant.md',
             '/en/guide/features/mcp-server',
             '/en/guide/features/ai-tools.md',
+            '/en/guide/features/shortcut-keys.md',
           ]
         },
         {


### PR DESCRIPTION
## Task

https://redmine.weseek.co.jp/issues/182047

## Summary
- Register `shortcut-keys.md` in sidebar configs for both `docs-growi-org` and `help-growi-cloud` so the page appears in navigation.
- The page itself was added in #597 but was missing from the sidebar entries, so it was not reachable from the docs/help site.

## Test plan
- [x] Verified the entry appears in the `docs-growi-org` dev server sidebar (ja/en)
- [x] Verified the entry appears in the `help-growi-cloud` dev server sidebar (ja/en)
- [ ] Check the deployed `docs.growi.org` and `growi.cloud/help` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)