### PR TITLE
Add GROWI v8.0.x upgrade guide and Vault pages

### DIFF
--- a/docs/.vuepress/config-docs-growi-org.js
+++ b/docs/.vuepress/config-docs-growi-org.js
@@ -170,6 +170,7 @@ module.exports = {
                 '/en/guide/features/ai-editor-assistant.md',
                 '/en/guide/features/mcp-server',
                 '/en/guide/features/ai-tools.md',
+                '/en/guide/features/vault.md',
                 '/en/guide/features/shortcut-keys.md'
               ]
             },
@@ -198,6 +199,7 @@ module.exports = {
               title: 'Upgrading',
               collapsable: false,
               children: [
+                '/en/admin-guide/upgrading/80x.md',
                 '/en/admin-guide/upgrading/75x.md',
                 '/en/admin-guide/upgrading/74x.md',
                 '/en/admin-guide/upgrading/73x.md',
@@ -292,6 +294,7 @@ module.exports = {
                 '/en/admin-guide/management-cookbook/audit-log.md',
                 '/en/admin-guide/management-cookbook/plugins.md',
                 '/en/admin-guide/management-cookbook/setup-ai.md',
+                '/en/admin-guide/management-cookbook/setup-vault.md',
                 '/en/admin-guide/management-cookbook/news.md',
               ],
             },
@@ -444,6 +447,7 @@ module.exports = {
                 '/ja/guide/features/ai-editor-assistant.md',
                 '/ja/guide/features/mcp-server.md',
                 '/ja/guide/features/ai-tools.md',
+                '/ja/guide/features/vault.md',
                 '/ja/guide/features/shortcut-keys.md'
               ]
             },
@@ -473,6 +477,7 @@ module.exports = {
               title: 'アップグレード',
               collapsable: false,
               children: [
+                '/ja/admin-guide/upgrading/80x.md',
                 '/ja/admin-guide/upgrading/75x.md',
                 '/ja/admin-guide/upgrading/74x.md',
                 '/ja/admin-guide/upgrading/73x.md',
@@ -567,6 +572,7 @@ module.exports = {
                 '/ja/admin-guide/management-cookbook/audit-log.md',
                 '/ja/admin-guide/management-cookbook/plugins.md',
                 '/ja/admin-guide/management-cookbook/setup-ai.md',
+                '/ja/admin-guide/management-cookbook/setup-vault.md',
                 '/ja/admin-guide/management-cookbook/news.md',
               ],
             },

--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -211,6 +211,7 @@ module.exports = {
           'title': 'アップグレードガイド',
           'key': 'upgrade-guide',
           'children': [
+            '/ja/admin-guide/upgrading/80x.md',
             '/ja/admin-guide/upgrading/74x.md',
             '/ja/admin-guide/upgrading/73x.md',
             '/ja/admin-guide/upgrading/72x.md',
@@ -380,6 +381,7 @@ module.exports = {
           'title': 'Uupgrade guide',
           'key': 'upgrade-guide',
           'children': [
+            '/en/admin-guide/upgrading/80x.md',
             '/en/admin-guide/upgrading/74x.md',
             '/en/admin-guide/upgrading/73x.md',
             '/en/admin-guide/upgrading/72x.md',

--- a/docs/en/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/en/admin-guide/admin-cookbook/env-vars.md
@@ -10,6 +10,8 @@ pageClass: admin-cookbook-env-vars
 | ------------------- | ----------  | ------------- |
 | `APP_SITE_URL` | Site URL. e.g. `https://example.com`, `https://example.com:8080` | |
 | `MONGO_URI` | URI to connect to MongoDB. | `mongodb://localhost/growi` |
+| `MONGO_MAX_POOL_SIZE` | Maximum number of connections in the MongoDB connection pool. Raise it when a large environment with many active users runs short on concurrency. | `15` |
+| `MONGO_MIN_POOL_SIZE` | Minimum number of connections in the MongoDB connection pool. | `2` |
 | `PASSWORD_SEED` | A password seed used by the password hash generator. | |
 | `SECRET_TOKEN` | A secret key for verifying the integrity of signed cookies. | |
 | `SESSION_NAME` | The name of the session ID cookie to set in the response by Express. | `connect.sid` |
@@ -130,5 +132,33 @@ pageClass: admin-cookbook-env-vars
 | `OAUTH_GITHUB_CLIENT_SECRET` | GitHub API client secret for OAuth login. | |
 | `OAUTH_TWITTER_CONSUMER_KEY` | Twitter consumer key(API key) for OAuth login. | |
 | `OAUTH_TWITTER_CONSUMER_SECRET` | Twitter consumer secret(API secret) for OAuth login. | |
+| **GROWI Vault options** | | |
+| `VAULT_ENABLED` | Enables the GROWI Vault feature (fixed at deploy time; no runtime toggle). | `false` |
+| `VAULT_MANAGER_ENDPOINT` | URL the GROWI app uses to reach the vault-manager service (required to enable Vault). | |
+| `VAULT_MANAGER_INTERNAL_SECRET` | Shared secret for app-to-vault-manager authentication. **Must be set in production and kept confidential.** | |
+| `VAULT_REPO_PATH` | Filesystem path of the bare Git repository managed by vault-manager. | `/data/vault-repo.git` |
+| `VAULT_BOOTSTRAP_ON_START` | Run the initial bootstrap at startup (`true` / `false` / `force`). | `false` |
+| `VAULT_BOOTSTRAP_RETRY_MAX` | Maximum number of bootstrap retry attempts. | `5` |
+| `VAULT_BOOTSTRAP_RETRY_BASE_MS` | Base backoff delay between bootstrap retries (ms). | `30000` |
+| `VAULT_BOOTSTRAP_RETRY_MAX_MS` | Cap on the bootstrap retry backoff delay (ms). | `1800000` |
+| `VAULT_BOOTSTRAP_RETRY_DISABLED` | Disables automatic bootstrap retries. | `false` |
+| `VAULT_BOOTSTRAP_HEARTBEAT_INTERVAL_MS` | Interval for bootstrap heartbeat writes (ms). | `10000` |
+| `VAULT_BOOTSTRAP_HEARTBEAT_STALE_MS` | Age after which a running bootstrap heartbeat is considered stale (ms). | `60000` |
+| `VAULT_DRIFT_DETECTION_DISABLED` | Disables the post-bootstrap drift detection sweep. | `false` |
+| `VAULT_DRIFT_DETECTION_INTERVAL_MS` | Interval between drift detection ticks (ms). | `300000` |
+| `VAULT_DRIFT_MAX_PAGES_PER_TICK` | Maximum pages scanned per drift detection tick. | `10000` |
+| `VAULT_RECONCILE_MAX_PAGES_PER_USER_REQUEST` | Maximum pages for a user-triggered reconcile request. | `1000` |
+| `VAULT_RECONCILE_MAX_PAGES_PER_ADMIN_REQUEST` | Maximum pages for an admin-triggered reconcile request. | `1000` |
+| `VAULT_RECONCILE_MAX_CONCURRENT_PER_USER` | Maximum concurrent reconcile jobs per user. | `1` |
+| `VAULT_RECONCILE_MAX_CONCURRENT_SYSTEM` | Maximum concurrent reconcile jobs system-wide. | `3` |
+| `VAULT_RECONCILE_CHUNK_SIZE` | Page batch size per reconcile processing chunk. | `100` |
+| `VAULT_RECONCILE_HISTORY_RETENTION_DAYS` | Days to retain reconcile history log entries. | `30` |
+| `VAULT_RECONCILE_REJECT_WHEN_BOOTSTRAP_NOT_DONE` | Rejects reconcile requests while bootstrap is incomplete. | `true` |
+| `VAULT_RECONCILE_ADMIN_BYPASS_CAPACITY_LIMIT` | Lets admin reconcile requests bypass the system concurrency limit. | `false` |
+| `VAULT_MAINTENANCE_TICK_MS` | vault-manager maintenance loop tick interval (ms); drives squash/gc checks. | `300000` |
+| `VAULT_SQUASH_COMMIT_THRESHOLD` | Commit count per namespace above which history is squashed. | `1000` |
+| `VAULT_SQUASH_AGE_HOURS` | Hours since the last squash that forces another squash. | `1` |
+| `VAULT_GC_LOOSE_OBJECT_THRESHOLD` | Loose-object count above which `git gc` runs. | `50000` |
+| `VAULT_GC_INTERVAL_HOURS` | Hours between `git gc` runs. | `24` |
 
 <!-- textlint-enable weseek/sentence-length -->

--- a/docs/en/admin-guide/management-cookbook/setup-vault.md
+++ b/docs/en/admin-guide/management-cookbook/setup-vault.md
@@ -1,0 +1,30 @@
+# Setting up GROWI Vault
+
+This page describes how to set up [GROWI Vault](/en/guide/features/vault.html).
+
+GROWI Vault consists of two parts: a gateway built into the GROWI app itself (served at `/vault.git`) and a standalone vault-manager service (a container). The vault-manager keeps a bare Git repository on a shared filesystem, and ingests page changes through MongoDB change streams.
+
+## Prerequisites
+
+- **MongoDB replica set**: Because GROWI Vault uses MongoDB change streams, MongoDB must run as a replica set (a single-node replica set is acceptable). See [Upgrading to GROWI v8.0.x](/en/admin-guide/upgrading/80x.html) for details.
+- **Shared filesystem**: A persistent filesystem is required for vault-manager to keep the bare Git repository.
+
+## Setup steps
+
+1. Deploy the vault-manager service (container). For the concrete container definition, refer to the updates in [growi-docker-compose](https://github.com/growilabs/growi-docker-compose).
+2. Set the environment variables for connectivity and authentication on both the GROWI app and vault-manager (see below).
+3. Restart GROWI and run the initial bootstrap from `/admin/vault` in the admin panel. You can monitor the bootstrap progress and storage status on the same screen.
+
+## Key environment variables
+
+The minimum environment variables required for setup are below. Tuning options such as retries, drift detection, reconcile, and gc are also available. See the "GROWI Vault options" section of the [Environment variables](/en/admin-guide/admin-cookbook/env-vars.html) page for the full list.
+
+- `VAULT_ENABLED`: Enables the GROWI Vault feature.
+- `VAULT_MANAGER_ENDPOINT`: The URL the GROWI app uses to reach vault-manager.
+- `VAULT_MANAGER_INTERNAL_SECRET`: The shared secret for authentication between the app and vault-manager.
+- `VAULT_REPO_PATH`: The path of the bare Git repository managed by vault-manager.
+- `VAULT_BOOTSTRAP_ON_START`: Whether to run the initial bootstrap at startup.
+
+::: warning
+`VAULT_MANAGER_INTERNAL_SECRET` is a secret. In production, set a hard-to-guess value, keep it out of repositories and logs, and manage it securely.
+:::

--- a/docs/en/admin-guide/upgrading/80x.md
+++ b/docs/en/admin-guide/upgrading/80x.md
@@ -1,0 +1,111 @@
+# Upgrading to GROWI v8.0.x
+
+GROWI v8.0 is a major update that redesigns GROWI AI around an agent-driven architecture and introduces GROWI Vault. It also changes some default values as part of optimizing the server's memory usage.
+
+
+## Table of Contents
+
+[[toc]]
+
+
+## [Deprecated] Legacy GROWI AI features and settings
+
+As part of redesigning GROWI AI around an agent-driven architecture, some of the legacy AI features have been removed. Their roles are taken over by the new agent-driven GROWI AI (see "[New Feature] Agent-driven GROWI AI" below).
+
+- **Knowledge assistant creation**: The ability to create new [knowledge assistants](/en/guide/features/ai-knowledge-assistant.html) has been removed.
+- **Editor assistant**: The [editor assistant](/en/guide/features/ai-editor-assistant.html) has been removed.
+
+<ContextualBlock context="docs-growi-org">
+
+::: warning
+The legacy AI integration settings have been removed and the configuration method has been overhauled. If you use the AI integration features, they will not work as-is after the upgrade and reconfiguration is required. For the configuration steps, see [Setting up and managing AI integration](/en/admin-guide/management-cookbook/setup-ai.html).
+:::
+
+</ContextualBlock>
+
+
+## For Users
+
+### [New Feature] GROWI Vault
+
+GROWI Vault is a read-only Git interface that lets you retrieve the pages you are allowed to view as a Git repository. When you clone it with your Git client, you get the pages within your permissions as a tree of Markdown files. For usage, see [GROWI Vault](/en/guide/features/vault.html).
+
+<ContextualBlock context="docs-growi-org">
+
+To use GROWI Vault, you need to deploy and enable a dedicated container. For the setup steps, see [Setting up GROWI Vault](/en/admin-guide/management-cookbook/setup-vault.html).
+
+::: warning
+The setup involves configuring a secret for internal communication. Keep this secret confidential and manage it securely.
+:::
+
+</ContextualBlock>
+
+<ContextualBlock context="help-growi-cloud">
+
+::: tip
+GROWI Vault on GROWI.cloud is planned for a later release. Please wait until it becomes available.
+:::
+
+</ContextualBlock>
+
+### [New Feature] Agent-driven GROWI AI
+
+GROWI AI has been redesigned into an agent-driven system that searches and reasons on its own to meet your goal, actively exploring pages within the wiki as it answers.
+
+In addition, in the AI chat input field you can now type `@` followed by text to search for pages and pass a selected page to the AI as context. For usage, see [AI chat](/en/guide/features/ai-tools.html).
+
+<ContextualBlock context="docs-growi-org">
+
+With agent-driven GROWI AI, you can choose the LLM provider from OpenAI / Anthropic / Google / Azure OpenAI. For configuration, see [Setting up and managing AI integration](/en/admin-guide/management-cookbook/setup-ai.html).
+
+</ContextualBlock>
+
+
+## For Administrators
+
+<ContextualBlock context="docs-growi-org">
+
+### [Action Required] MongoDB replica set is now required
+
+Because GROWI Vault uses MongoDB change streams, v8.0 requires MongoDB to run as a replica set. Change streams are only available on a replica set.
+
+If you run a single-node standalone configuration (such as the default of [growi-docker-compose](https://github.com/growilabs/growi-docker-compose)), you need to migrate to a replica set. A single-node replica set is acceptable. For how to migrate, refer to the updates in [growi-docker-compose](https://github.com/growilabs/growi-docker-compose).
+
+</ContextualBlock>
+
+<ContextualBlock context="docs-growi-org">
+
+### [Action Required] Reduced default MongoDB connection pool size
+
+To optimize the server's memory usage, the default upper limit of the MongoDB connection pool has been reduced. Most environments need no additional action.
+
+The required pool size depends on the concurrency of database operations being processed at the same time. The more active users, total pages, and access frequency you have, the higher the concurrency tends to be. As a rough guide, once you exceed several hundred active users (roughly 500), the default may be insufficient. In that case, raise the connection pool limit with an environment variable. For the environment variable to set, see the [Environment variables](/en/admin-guide/admin-cookbook/env-vars.html) page.
+
+</ContextualBlock>
+
+<ContextualBlock context="docs-growi-org">
+
+### [Specification Change] Fixed OpenTelemetry instrumentation set
+
+To reduce memory usage, OpenTelemetry instrumentation has been fixed to the minimal set that GROWI actually uses. Standard usage needs no additional action.
+
+If you previously switched the scope of auto-instrumentation with an environment variable, that variable has been removed. If you need to customize instrumentation, note that the configuration method has changed.
+
+</ContextualBlock>
+
+
+## Things to Check Before Upgrading
+
+<ContextualBlock context="docs-growi-org">
+
+- [x] Are you running MongoDB as a replica set? (If standalone, migration is required.)
+- [x] Do you use the AI integration features? (If so, reconfiguration with the new method is required after the upgrade.)
+- [x] Are you a large-scale environment with many active users? (If so, consider raising the MongoDB connection pool limit.)
+
+</ContextualBlock>
+
+<ContextualBlock context="help-growi-cloud">
+
+None.
+
+</ContextualBlock>

--- a/docs/en/guide/features/vault.md
+++ b/docs/en/guide/features/vault.md
@@ -1,0 +1,56 @@
+# GROWI Vault
+
+GROWI Vault is a read-only Git interface that lets you retrieve the pages you are allowed to view as a Git repository.
+
+::: tip
+GROWI Vault is available when an administrator enables it on a self-hosted instance. Availability on GROWI.cloud is planned for a later release.
+:::
+
+## What you can do
+
+- Retrieve the pages you are allowed to view (public, share-link, group, and only-me) as a tree of Markdown files.
+- The retrieved files mirror the page path hierarchy.
+
+## Creating an access token
+
+Cloning requires a GROWI access token. You can create one from "Access token settings" in the "API Settings" tab of "User Settings" (`/me`). The minimum required scope is `read:features:page`.
+
+## How to clone
+
+Clone with your Git client using the access token you created:
+
+```bash
+git clone https://x:<access-token>@<your-growi-host>/vault.git
+```
+
+If the `Authorization` header is already in use (for example, behind a reverse proxy that uses Basic auth), you can pass the token with the `X-GROWI-ACCESS-TOKEN` header:
+
+```bash
+git config http.<URL>.extraHeader "X-GROWI-ACCESS-TOKEN: <access-token>"
+```
+
+### Retrieving only a subset of pages
+
+To retrieve only the pages under a specific page path, use Git's sparse checkout. You can check out only the specified path without retrieving the entire repository.
+
+```bash
+git clone --filter=blob:none --sparse https://x:<access-token>@<your-growi-host>/vault.git
+cd vault
+git sparse-checkout set <page-path>
+```
+
+For `<page-path>`, specify the path of the pages you want to retrieve (e.g., `/projects/docs`).
+
+
+## Limitations (current)
+
+GROWI Vault is read-only. The following operations and data are out of scope:
+
+- Writing back with `git push`
+- Attachments, comments, likes, bookmarks, and tags
+- Revision history from before Vault was enabled
+- Drafts and unpublished pages
+
+## For administrators
+
+For how to enable and set up GROWI Vault, see [Setting up GROWI Vault](/en/admin-guide/management-cookbook/setup-vault.html).

--- a/docs/ja/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/ja/admin-guide/admin-cookbook/env-vars.md
@@ -9,6 +9,8 @@ pageClass: admin-cookbook-env-vars
 | ------------------- | ---------- | ------------- |
 | `APP_SITE_URL` | サイト URL (例: `https://example.com` 、 `https://example.com:8080`) | |
 | `MONGO_URI` | 接続する MongoDB サーバーの URI | `mongodb://localhost/growi` |
+| `MONGO_MAX_POOL_SIZE` | MongoDB コネクションプールの最大接続数。アクセス数の多い大規模な環境で同時実行の性能が不足する場合に引き上げます。 | `15` |
+| `MONGO_MIN_POOL_SIZE` | MongoDB コネクションプールの最小接続数。 | `2` |
 | `PASSWORD_SEED` | パスワードハッシュ生成時に使用されるパスワードシード | |
 | `SECRET_TOKEN` | 発行された cookie の正当性を検証するためのシークレットトークン | |
 | `SESSION_NAME` | Express からのレスポンスに含まれる cookie 内のセッション ID 名 | `connect.sid` |
@@ -131,3 +133,31 @@ pageClass: admin-cookbook-env-vars
 | `OAUTH_GITHUB_CLIENT_SECRET` | OAuth ログインで使用する GitHub API のクライアント シークレット | |
 | `OAUTH_TWITTER_CONSUMER_KEY` | OAuth ログインで使用する Twitter カスタマーキー (API キー) | |
 | `OAUTH_TWITTER_CONSUMER_SECRET` | OAuth ログインで使用する Twitter カスタマーシークレット(API シークレット) | |
+| **GROWI Vault オプション** | | |
+| `VAULT_ENABLED` | GROWI Vault 機能の有効化（デプロイ時に固定。実行時の切り替えは不可） | `false` |
+| `VAULT_MANAGER_ENDPOINT` | GROWI アプリが vault-manager サービスへ接続する URL（有効化には設定が必須） | |
+| `VAULT_MANAGER_INTERNAL_SECRET` | アプリと vault-manager 間の認証に使う共有シークレット。**本番では必ず設定し、外部に漏らさないこと** | |
+| `VAULT_REPO_PATH` | vault-manager が管理する bare Git リポジトリのファイルパス | `/data/vault-repo.git` |
+| `VAULT_BOOTSTRAP_ON_START` | 起動時に初期 bootstrap を実行する（`true` / `false` / `force`） | `false` |
+| `VAULT_BOOTSTRAP_RETRY_MAX` | bootstrap のリトライ最大回数 | `5` |
+| `VAULT_BOOTSTRAP_RETRY_BASE_MS` | bootstrap リトライの基本バックオフ時間（ミリ秒） | `30000` |
+| `VAULT_BOOTSTRAP_RETRY_MAX_MS` | bootstrap リトライのバックオフ上限（ミリ秒） | `1800000` |
+| `VAULT_BOOTSTRAP_RETRY_DISABLED` | bootstrap の自動リトライを無効化する | `false` |
+| `VAULT_BOOTSTRAP_HEARTBEAT_INTERVAL_MS` | bootstrap 実行中のハートビート書き込み間隔（ミリ秒） | `10000` |
+| `VAULT_BOOTSTRAP_HEARTBEAT_STALE_MS` | bootstrap のハートビートが古いと判断するまでの時間（ミリ秒） | `60000` |
+| `VAULT_DRIFT_DETECTION_DISABLED` | bootstrap 後の drift 検出スイープを無効化する | `false` |
+| `VAULT_DRIFT_DETECTION_INTERVAL_MS` | drift 検出の実行間隔（ミリ秒） | `300000` |
+| `VAULT_DRIFT_MAX_PAGES_PER_TICK` | drift 検出 1 回あたりにスキャンする最大ページ数 | `10000` |
+| `VAULT_RECONCILE_MAX_PAGES_PER_USER_REQUEST` | ユーザーによる reconcile 1 回あたりの最大ページ数 | `1000` |
+| `VAULT_RECONCILE_MAX_PAGES_PER_ADMIN_REQUEST` | 管理者による reconcile 1 回あたりの最大ページ数 | `1000` |
+| `VAULT_RECONCILE_MAX_CONCURRENT_PER_USER` | ユーザーごとの reconcile 同時実行数の上限 | `1` |
+| `VAULT_RECONCILE_MAX_CONCURRENT_SYSTEM` | システム全体での reconcile 同時実行数の上限 | `3` |
+| `VAULT_RECONCILE_CHUNK_SIZE` | reconcile 処理 1 チャンクあたりのページ数 | `100` |
+| `VAULT_RECONCILE_HISTORY_RETENTION_DAYS` | reconcile 履歴ログの保持日数 | `30` |
+| `VAULT_RECONCILE_REJECT_WHEN_BOOTSTRAP_NOT_DONE` | bootstrap 未完了時に reconcile 要求を拒否する | `true` |
+| `VAULT_RECONCILE_ADMIN_BYPASS_CAPACITY_LIMIT` | 管理者の reconcile 要求がシステム同時実行数の上限を超過できるようにする | `false` |
+| `VAULT_MAINTENANCE_TICK_MS` | vault-manager のメンテナンスループの tick 間隔（ミリ秒）。squash / gc の判定を駆動する | `300000` |
+| `VAULT_SQUASH_COMMIT_THRESHOLD` | namespace のコミット数がこの値を超えると履歴を squash する | `1000` |
+| `VAULT_SQUASH_AGE_HOURS` | 前回の squash からこの時間が経過すると squash を強制する（時間） | `1` |
+| `VAULT_GC_LOOSE_OBJECT_THRESHOLD` | loose object 数がこの値を超えると `git gc` を実行する | `50000` |
+| `VAULT_GC_INTERVAL_HOURS` | `git gc` を実行する間隔（時間） | `24` |

--- a/docs/ja/admin-guide/management-cookbook/setup-vault.md
+++ b/docs/ja/admin-guide/management-cookbook/setup-vault.md
@@ -1,0 +1,30 @@
+# GROWI Vault のセットアップ
+
+[GROWI Vault](/ja/guide/features/vault.html) を利用するためのセットアップ手順を説明します。
+
+GROWI Vault は、GROWI アプリ本体に組み込まれたゲートウェイ（`/vault.git` で公開）と、独立した vault-manager サービス（コンテナ）の 2 つで構成されます。vault-manager は、共有ファイルシステム上の bare Git リポジトリを保持します。ページの変更は MongoDB の change stream を通じて取り込まれます。
+
+## 前提条件
+
+- **MongoDB のレプリカセット構成**: GROWI Vault は MongoDB の change stream を使用するため、MongoDB をレプリカセット構成で運用する必要があります（単一ノードのレプリカセットでも可）。詳細は [v8.0.x へのアップグレード](/ja/admin-guide/upgrading/80x.html) を参照してください。
+- **共有ファイルシステム**: vault-manager が bare Git リポジトリを保持するための、永続的なファイルシステムが必要です。
+
+## セットアップの流れ
+
+1. vault-manager サービス（コンテナ）を配置します。具体的なコンテナ定義は [growi-docker-compose](https://github.com/growilabs/growi-docker-compose) の更新内容を参照してください。
+2. GROWI アプリと vault-manager の双方に、接続と認証のための環境変数を設定します（下記）。
+3. GROWI を再起動し、管理画面の `/admin/vault` から初期 bootstrap を実行します。bootstrap の進捗と保存状況は同じ画面で確認できます。
+
+## 主な環境変数
+
+セットアップに最低限必要な環境変数は次のとおりです。リトライ・drift 検出・reconcile・gc などのチューニング向けを含む全一覧は、[環境変数](/ja/admin-guide/admin-cookbook/env-vars.html) ページの「GROWI Vault オプション」を参照してください。
+
+- `VAULT_ENABLED`: GROWI Vault 機能を有効化します。
+- `VAULT_MANAGER_ENDPOINT`: GROWI アプリが vault-manager へ接続する URL です。
+- `VAULT_MANAGER_INTERNAL_SECRET`: アプリと vault-manager 間の認証に使う共有シークレットです。
+- `VAULT_REPO_PATH`: vault-manager が管理する bare Git リポジトリのパスです。
+- `VAULT_BOOTSTRAP_ON_START`: 起動時に初期 bootstrap を実行するかどうかを指定します。
+
+::: warning
+`VAULT_MANAGER_INTERNAL_SECRET` はシークレットです。本番環境では推測されにくい値を設定し、リポジトリやログに残さず、外部に漏らさないよう安全に管理してください。
+:::

--- a/docs/ja/admin-guide/upgrading/80x.md
+++ b/docs/ja/admin-guide/upgrading/80x.md
@@ -1,0 +1,111 @@
+# GROWI v8.0.x へのアップグレード
+
+GROWI v8.0 は、GROWI AI をエージェント駆動へ全面的に刷新し、新たに GROWI Vault を追加するメジャーアップデートです。あわせて、サーバーのメモリ使用量を最適化するための既定値の変更が含まれます。
+
+
+## 目次
+
+[[toc]]
+
+
+## [廃止] 旧 GROWI AI 機能・設定の廃止
+
+GROWI AI のエージェント駆動への全面刷新に伴い、従来の AI 機能の一部が廃止されました。これらの役割は、新しいエージェント駆動の GROWI AI（後述の「[新機能] エージェント駆動 GROWI AI」）が引き継ぎます。
+
+- **ナレッジアシスタントの作成機能**: [ナレッジアシスタント](/ja/guide/features/ai-knowledge-assistant.html) を新規に作成する機能は廃止されました。
+- **エディターアシスタント**: [エディターアシスタント](/ja/guide/features/ai-editor-assistant.html) は廃止されました。
+
+<ContextualBlock context="docs-growi-org">
+
+::: warning
+従来の AI 連携設定は廃止され、設定方法が一新されました。AI 連携機能を利用している場合、アップグレード後はそのまま動作しません。新しい設定方法に沿った再設定が必要です。設定手順は [AI 連携機能のセットアップと管理](/ja/admin-guide/management-cookbook/setup-ai.html) を参照してください。
+:::
+
+</ContextualBlock>
+
+
+## 利用者向け
+
+### [新機能] GROWI Vault
+
+GROWI Vault は、自分が閲覧権限を持つページを Git リポジトリとして取得できる、読み取り専用の Git インターフェースです。手元の Git クライアントでクローンすると、権限の範囲内のページが Markdown ファイルのツリーとして得られます。使い方は [GROWI Vault](/ja/guide/features/vault.html) を参照してください。
+
+<ContextualBlock context="docs-growi-org">
+
+GROWI Vault を利用するには、専用コンテナの追加と有効化が必要です。セットアップ手順は [GROWI Vault のセットアップ](/ja/admin-guide/management-cookbook/setup-vault.html) を参照してください。
+
+::: warning
+セットアップでは内部通信用のシークレットを設定します。シークレットは外部に漏らさず、安全に管理してください。
+:::
+
+</ContextualBlock>
+
+<ContextualBlock context="help-growi-cloud">
+
+::: tip
+GROWI.cloud での GROWI Vault の提供開始は、もう少し先を予定しています。提供開始までお待ちください。
+:::
+
+</ContextualBlock>
+
+### [新機能] エージェント駆動 GROWI AI
+
+GROWI AI が、目的に応じて自ら検索と推論を繰り返すエージェント駆動の仕組みに刷新されました。ウィキ内のページを能動的に探索しながら回答します。
+
+あわせて、AI チャットの入力欄で `@` に続けて文字列を入力するとページを検索でき、候補から選んだページをそのまま文脈として AI へ渡せるようになりました。使い方は [AI チャット](/ja/guide/features/ai-tools.html) を参照してください。
+
+<ContextualBlock context="docs-growi-org">
+
+エージェント駆動 GROWI AI では、利用する LLM プロバイダを OpenAI / Anthropic / Google / Azure OpenAI から選択できます。設定方法は [AI 連携機能のセットアップと管理](/ja/admin-guide/management-cookbook/setup-ai.html) を参照してください。
+
+</ContextualBlock>
+
+
+## 管理者向け
+
+<ContextualBlock context="docs-growi-org">
+
+### [要対応] MongoDB のレプリカセット構成が必須
+
+GROWI Vault が MongoDB の change stream を使用するため、v8.0 では MongoDB をレプリカセット構成で運用する必要があります。change stream はレプリカセット構成でのみ利用できます。
+
+単一ノードの standalone 構成（[growi-docker-compose](https://github.com/growilabs/growi-docker-compose) の既定など）で運用している場合は、レプリカセット構成へ移行してください。単一ノードのレプリカセットでも利用できます。移行方法は [growi-docker-compose](https://github.com/growilabs/growi-docker-compose) の更新内容を参照してください。
+
+</ContextualBlock>
+
+<ContextualBlock context="docs-growi-org">
+
+### [要対応] MongoDB コネクションプール既定値の縮小
+
+サーバーのメモリ使用量を最適化するため、MongoDB へのコネクションプールの既定の上限値が、従来より小さい値に変更されました。多くの環境では追加の対応は不要です。
+
+必要なプールの大きさは、同時に処理される DB アクセスの並行度で決まります。アクティブユーザー数や総ページ数、アクセス頻度が増えるほど並行度は高くなります。目安として、アクティブユーザーが数百人（おおむね 500 人）を超える規模では、既定値のままだと不足しがちです。その場合は、コネクションプールの上限を環境変数で引き上げてください。設定する環境変数は [環境変数](/ja/admin-guide/admin-cookbook/env-vars.html) ページを参照してください。
+
+</ContextualBlock>
+
+<ContextualBlock context="docs-growi-org">
+
+### [仕様変更] OpenTelemetry 計装セットの固定化
+
+メモリ使用量を削減するため、OpenTelemetry の計装が、GROWI が実際に使用する必要最小限のセットに固定されました。標準的な利用では追加の対応は不要です。
+
+従来、自動計装の範囲を環境変数で切り替えていた場合、その環境変数は廃止されました。計装をカスタマイズする必要がある場合は設定方法が変わっているため、ご注意ください。
+
+</ContextualBlock>
+
+
+## アップグレード前にチェックすべきこと
+
+<ContextualBlock context="docs-growi-org">
+
+- [x] MongoDB をレプリカセット構成で運用しているか（standalone 構成の場合は移行が必要）
+- [x] AI 連携機能を利用しているか（利用している場合、アップグレード後に新しい設定方法での再設定が必要）
+- [x] アクセス数の多い大規模な環境か（該当する場合、MongoDB コネクションプール上限の調整を検討）
+
+</ContextualBlock>
+
+<ContextualBlock context="help-growi-cloud">
+
+なし。
+
+</ContextualBlock>

--- a/docs/ja/guide/features/vault.md
+++ b/docs/ja/guide/features/vault.md
@@ -1,0 +1,56 @@
+# GROWI Vault
+
+GROWI Vault は、自分が閲覧権限を持つページを Git リポジトリとして取得できる、読み取り専用の Git インターフェースです。
+
+::: tip
+GROWI Vault は、self-hosted 環境で管理者が有効化した場合に利用できます。GROWI.cloud での提供開始は、もう少し先を予定しています。
+:::
+
+## できること
+
+- 自分が閲覧権限を持つページ（全体公開・リンク共有・グループ・自分のみ）を、Markdown ファイルのツリーとして取得できます。
+- 取得したファイルは、ページのパス構成をそのまま反映します。
+
+## アクセストークンの作成
+
+クローンには GROWI のアクセストークンが必要です。「ユーザー設定」（`/me`）の「API設定」タブにある「Access token 設定」から作成できます。最低限必要な権限（scope）は `read:features:page` です。
+
+## クローン方法
+
+手元の Git クライアントで、作成したアクセストークンを使って次のようにクローンします。
+
+```bash
+git clone https://x:<アクセストークン>@<GROWI のホスト>/vault.git
+```
+
+リバースプロキシで Basic 認証を併用しているなど、`Authorization` ヘッダーが既に使われている環境では、`X-GROWI-ACCESS-TOKEN` ヘッダーでトークンを渡せます。
+
+```bash
+git config http.<URL>.extraHeader "X-GROWI-ACCESS-TOKEN: <アクセストークン>"
+```
+
+### 一部のページパス配下のみを取得する
+
+特定のページパス配下だけを取得したい場合は、Git の sparse checkout を使います。リポジトリ全体を取得せずに、指定したパス配下だけをチェックアウトできます。
+
+```bash
+git clone --filter=blob:none --sparse https://x:<アクセストークン>@<GROWI のホスト>/vault.git
+cd vault
+git sparse-checkout set <ページパス>
+```
+
+`<ページパス>` には、取得したいページのパスを指定します（例: `/projects/docs`）。
+
+
+## 制限事項（現時点）
+
+GROWI Vault は読み取り専用です。次の操作・データは対象外です。
+
+- `git push` による書き込み
+- 添付ファイル・コメント・いいね・ブックマーク・タグ
+- Vault を有効化する前のリビジョン履歴
+- 下書き・未公開ページ
+
+## 管理者向け
+
+GROWI Vault の有効化とセットアップの手順は [GROWI Vault のセットアップ](/ja/admin-guide/management-cookbook/setup-vault.html) を参照してください。


### PR DESCRIPTION
Add the bilingual v8.0.x upgrade guide (80x.md) covering GROWI Vault, agent-driven GROWI AI, deprecation of legacy AI features/settings, the new MongoDB replica set requirement, and the reduced connection pool default. Add dedicated GROWI Vault user and setup pages, register the new pages in the docs-growi-org sidebars, and document the new MONGO_* and VAULT_* environment variables in env-vars.