### PR TITLE
fix: Dockerfile ビルド時の pnpm インストールエラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /growi-docs
 
 COPY . .
 
-RUN apt-get update && apt-get install -y ca-certificates wget --no-install-recommends \
+RUN apt-get update && apt-get install -y ca-certificates wget libatomic1 --no-install-recommends \
   && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 ENV PNPM_HOME="/root/.local/share/pnpm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ WORKDIR /growi-docs
 
 COPY . .
 
-RUN apt-get update && apt-get install -y ca-certificates wget libatomic1 --no-install-recommends \
-  && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
-
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+
+RUN apt-get update && apt-get install -y ca-certificates wget libatomic1 --no-install-recommends \
+  && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 RUN pnpm install
 RUN pnpm run help-growi-cloud:build


### PR DESCRIPTION
- libatomic.so.1 が見つからず pnpm バイナリのダウンロードに失敗していたため、apt-get install に libatomic1 を追加。
    ```
    ==> Downloading pnpm binaries 11.13.1
    /tmp/tmp.OTMv3CXTqE/pnpm: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
    Install Error!
    ```
- RUN 命令より後に ENV PNPM_HOME/PATH を宣言していたため、pnpm セルフインストール処理が「global bin directory is not in PATH」で失敗していた
- ENV を RUN の前に移動して解消