### PR TITLE
docs: v7.5.x アップグレードガイドに Node.js v24 の記載を追加

### DIFF
--- a/docs/en/admin-guide/upgrading/75x.md
+++ b/docs/en/admin-guide/upgrading/75x.md
@@ -49,6 +49,29 @@ Note that this does not resolve every case.
 
 ## For Administrators
 
+<ContextualBlock context="docs-growi-org">
+
+### [Action Required] Upgrade to Node.js v24
+
+::: tip
+
+- Systems using the [official Docker image](https://hub.docker.com/r/growilabs/growi/) are not affected
+:::
+
+Starting with GROWI v7.5.0, only Node.js v24 is supported. Support for v18 and v20 has ended.
+
+| GROWI | <= v7.4.x | v7.5.x |
+| :---: | :---: | :---: |
+| Node.js | 18, 20 | 24 |
+
+If you build and run GROWI from source, upgrade the Node.js runtime to v24 before upgrading GROWI.
+
+::: warning
+v7.5.0 uses `RegExp.escape()`, a built-in function added in Node.js v24, in its page path handling. If you upgrade while still on v18 or v20, that function does not exist and operations such as moving or duplicating pages fail at runtime. Staying on the older runtime is not a viable option.
+:::
+
+</ContextualBlock>
+
 ### [Security] Change of the base image used by the official Docker image
 
 The base image of the official GROWI Docker image has been changed to [Docker Hardened Images (DHI)](https://www.docker.com/products/hardened-images/).
@@ -94,6 +117,8 @@ This is useful for archival purposes and for analysis in external tools.
 
 ## Things to Check Before Upgrading
 
+- [x] Do you build and run GROWI from source?
+  - [x] Has the Node.js runtime been upgraded to v24?
 - [x] Are you using S3 or S3-compatible object storage?
   - [x] Has the `s3:AbortMultipartUpload` permission been added to your IAM policy?
 - [x] Are you using the official GROWI Docker image?

--- a/docs/ja/admin-guide/upgrading/75x.md
+++ b/docs/ja/admin-guide/upgrading/75x.md
@@ -49,6 +49,29 @@ v7.4 系までの実装で一部動作しなくなっていたキーバインド
 
 ## 管理者向け
 
+<ContextualBlock context="docs-growi-org">
+
+### [要対応] Node.js v24 へのアップグレード
+
+::: tip
+
+- [公式の Docker イメージ](https://hub.docker.com/r/growilabs/growi/)を利用しているシステムには影響はありません
+:::
+
+GROWI v7.5.0 で、サポート対象の Node.js が v24 系のみになりました。v18 系・v20 系のサポートは終了しています。
+
+| GROWI | <= v7.4.x | v7.5.x |
+| :---: | :---: | :---: |
+| Node.js | 18, 20 | 24 |
+
+ソースコードから GROWI をビルド・実行しているシステムでは、アップグレード前に実行環境の Node.js を v24 系へ上げてください。
+
+::: warning
+v7.5.0 では、Node.js v24 で追加された組み込み関数 `RegExp.escape()` をページパスの処理で利用しています。v18 系・v20 系のままアップグレードすると、この関数が存在しないため、ページの移動・複製などの操作が実行時エラーとなります。バージョンを上げずに運用を続けることはできません。
+:::
+
+</ContextualBlock>
+
 ### [セキュリティ] 公式 Docker イメージのベースイメージを変更
 
 公式 GROWI Docker イメージのベースイメージを [Docker Hardened Images (DHI)](https://www.docker.com/products/hardened-images/) に変更しました。
@@ -93,6 +116,8 @@ IAM ポリシーに `s3:AbortMultipartUpload` 権限を追加してください�
 
 ## アップグレード前にチェックすべきこと
 
+- [x] ソースコードから GROWI をビルド・実行しているか
+  - [x] 実行環境の Node.js を v24 系へアップグレードしたか
 - [x] S3 互換オブジェクトストレージを利用しているか
   - [x] IAM ポリシーに `s3:AbortMultipartUpload` 権限を追加したか
 - [x] 公式の GROWI Docker イメージを利用しているか


### PR DESCRIPTION
## 概要

v7.5.x のアップグレードガイド（[75x.md](https://github.com/growilabs/growi-docs/blob/master/docs/ja/admin-guide/upgrading/75x.md)）に、Node.js v24 が必須になったことの記載が抜けていたため追加します。ja / en 両方に入れています。

## 背景: Node.js v24 化は v7.5.0 で入っている

growi 本体の tag を突き合わせて確認しました。

| 確認項目 | v7.4.0 〜 v7.4.7 | **v7.5.0 以降** | v8.0.0 |
| --- | --- | --- | --- |
| `package.json` の `engines.node` | `^18 \|\| ^20` | `^24` | `^24`（変更なし） |
| 公式 Docker イメージのベース | `node:20-slim` | `dhi.io/node:24-debian13` | 同じ |
| CI の `node-version` | `20.x` | `24.x` | 同じ |
| README の Dependencies | `Node.js v18.x or v20.x` | `Node.js v24.x` | 同じ |

該当コミットは growilabs/growi の `e153c43` "update to node v24"（2026-02-24）で、v7.5.0 に含まれています。v7.4 系は最終の v7.4.7 まで `^18 || ^20` のままで、v8.0.0 では Node.js のバージョンは変わっていません。

既存の 75x.md には DHI ベースイメージへの変更は書かれていましたが、これは公式 Docker イメージを使う場合の話で、**ソースコードからビルド・実行しているシステム向けの案内が無い**状態でした。

## Node.js v24 は推奨ではなく必須

v7.5.0 で `escape-string-regexp` が Node.js 24 組み込みの `RegExp.escape()` に置き換えられ、`packages/core/src/utils/page-path-utils/index.ts` のページパス処理で実際に使われています。v18 / v20 のままアップグレードするとこの関数が存在せず、ページの移動・複製が実行時エラーになります。そのため `[要対応]` として書き、警告ブロックで「バージョンを上げずに運用を続けることはできない」ことを明示しました。

## 記述方針

- `<ContextualBlock context="docs-growi-org">` で囲み、help.growi.cloud 側には出していません（実行環境の Node.js バージョンは GROWI.cloud 利用者には無関係）。[73x.md](https://github.com/growilabs/growi-docs/blob/master/docs/ja/admin-guide/upgrading/73x.md) / [70x.md](https://github.com/growilabs/growi-docs/blob/master/docs/ja/admin-guide/upgrading/70x.md) の Node.js セクションと同じ扱いです。
- バージョン対応表と「公式 Docker イメージ利用者には影響なし」の tip も、73x.md の書式を踏襲しています。
- 「アップグレード前にチェックすべきこと」にも項目を追加しました。
- 配置は「管理者向け」の先頭（DHI ベースイメージの節より前）とし、実行環境の話を先に読ませています。

## 80x.md について

当初 80x.md への追記を検討しましたが、v8.0 では Node.js のバージョンが変わっていないため、v8.0 の変更として書くと事実に反します。今回は 80x.md には手を入れていません。v7.4 以前から v8.0 へ一気に上げる利用者への導線が必要であれば、80x.md のチェックリストに 75x.md への参照を 1 行足す形が考えられます（別 PR でも可）。

## 確認したこと

- `pnpm textlint docs/ja/admin-guide/upgrading/75x.md docs/en/admin-guide/upgrading/75x.md` → エラーなし（exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
