### PR TITLE
fix: correct PNPM_HOME PATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /growi-docs
 COPY . .
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 
 RUN apt-get update && apt-get install -y ca-certificates wget libatomic1 --no-install-recommends \
   && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -


### PR DESCRIPTION
pnpm installer places its binary shim under $PNPM_HOME/bin, but the PATH only included $PNPM_HOME, causing "pnpm: not found" once the install layer's cache was invalidated and a newer pnpm was fetched.
