### PR TITLE
fix: install pnpm before copying project files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ FROM node:20-slim AS builder
 
 WORKDIR /growi-docs
 
-COPY . .
-
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
 
 RUN apt-get update && apt-get install -y ca-certificates wget libatomic1 --no-install-recommends \
   && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+
+COPY . .
 
 RUN pnpm install
 RUN pnpm run help-growi-cloud:build


### PR DESCRIPTION
- COPY を pnpm install より後ろに移動し、package.json が存在しない状態で pnpm をセットアップするようにした。
- install.sh でセットアップされる pnpm はディスパッチャとして動作し、実行時に package.json の packageManager フィールドを見て該当バージョンに委譲するため、ビルドで実際に使われる pnpm は引き続き packageManager 指定の バージョン (10.11.0) になる。