### PR TITLE
docs(upgrading): fix two mislabeled version tables in the upgrade guides

### DIFF
--- a/docs/en/admin-guide/upgrading/80x.md
+++ b/docs/en/admin-guide/upgrading/80x.md
@@ -89,7 +89,7 @@ The required pool size depends on the concurrency of database operations being p
 
 GROWI v8.0 removes the code for Elasticsearch v7. The only supported versions are now v8 and v9 (the default remains v9).
 
-| GROWI | <= v7.3.x | v8.0.x |
+| GROWI | <= v7.5.x | v8.0.x |
 | :---: | :---: | :---: |
 | Elasticsearch | 7.x, 8.x, 9.x | 8.x, 9.x |
 

--- a/docs/ja/admin-guide/upgrading/73x.md
+++ b/docs/ja/admin-guide/upgrading/73x.md
@@ -85,7 +85,7 @@ GROWI v7.3.0 で MongoDB v8 のサポートが追加されました。
 
 | GROWI | <= v7.2.x | v7.3.x |
 | :---: | :---: | :---: |
-| Elasticsearch | 6.x | 6.x, 8.x |
+| MongoDB | 6.x | 6.x, 8.x |
 
 ### [サポート追加] Elasticsearch v9 のサポート
 

--- a/docs/ja/admin-guide/upgrading/80x.md
+++ b/docs/ja/admin-guide/upgrading/80x.md
@@ -89,7 +89,7 @@ GROWI Vault が MongoDB の change stream を使用するため、v8.0 では Mo
 
 GROWI v8.0 では、Elasticsearch v7 系のためのコードが削除されました。対応する Elasticsearch のバージョンは v8 系・v9 系のみになりました（デフォルトの利用バージョンは引き続き v9 系です）。
 
-| GROWI | <= v7.3.x | v8.0.x |
+| GROWI | <= v7.5.x | v8.0.x |
 | :---: | :---: | :---: |
 | Elasticsearch | 7.x, 8.x, 9.x | 8.x, 9.x |
 


### PR DESCRIPTION
## 概要

`admin-guide/upgrading/` 配下のバージョン対応表にある誤記 2 件を修正します。

いずれも **#604（アップグレード概要ページの刷新）の作業中に発見** したものです。概要ページの記載は各バージョンのアップグレードガイドを正典として突き合わせており、その過程で「どちらが正なのか判断できない記述」として浮かび上がりました。概要ページ側とは独立して先に直したいため、本 PR を分けています。

## 1. `ja/73x.md` の表の行ラベルが `Elasticsearch` になっている

「[サポート追加] MongoDB v8 のサポート」節の表なのに、行ラベルが `Elasticsearch` になっていました。値（`6.x` → `6.x, 8.x`）は MongoDB のバージョンです。英語版 `en/73x.md` は同じ表を `MongoDB` とラベルしており、**日本語版のみの誤記**です。

```diff
 GROWI v7.3.0 で MongoDB v8 のサポートが追加されました。

 | GROWI | <= v7.2.x | v7.3.x |
 | :---: | :---: | :---: |
-| Elasticsearch | 6.x | 6.x, 8.x |
+| MongoDB | 6.x | 6.x, 8.x |
```

単体の誤りであるだけでなく、ページを参照資料として使えなくしている点が問題でした。`73x.md` を Elasticsearch で検索すると 2 つの表がヒットし、「v7.2 以前の対応 Elasticsearch は `6.x`」と「`7.x, 8.x`」という矛盾した情報が同時に返ります。

## 2. `ja/en 80x.md` の Elasticsearch 表の左列ヘッダ

他のアップグレードガイドの表は、左列に**そのページが扱うバージョンの直前の系列**を置く形で統一されています。

| ファイル | 左列 | 右列 |
| :--- | :--- | :--- |
| 34x.md | `<= v3.3.x` | `v3.4.x` |
| 61x.md | `<= v6.0.x` | `v6.1.x` |
| 70x.md | `<= v6.3.x` | `v7.0.x` |
| 73x.md | `<= v7.2.x` | `v7.3.x` |
| 75x.md | `<= v7.4.x` | `v7.5.x` |
| **80x.md** | **`<= v7.3.x`** | `v8.0.x` |

80x.md だけが直前の系列（`v7.5.x`）になっていなかったため、慣例に揃えます。

```diff
-| GROWI | <= v7.3.x | v8.0.x |
+| GROWI | <= v7.5.x | v8.0.x |
 | :---: | :---: | :---: |
 | Elasticsearch | 7.x, 8.x, 9.x | 8.x, 9.x |
```

`v7.3.x` は、73x.md の Elasticsearch v9 対応表の**右列**（`v7.3.x` / `7.x, 8.x, 9.x`）からセルごと引き写された際に、バージョンラベルも一緒に持ち込まれたものと思われます。GROWI v7.5 系でも `ELASTICSEARCH_VERSION` は `7` / `8` / `9` を受け付けるため、**セルの値（`7.x, 8.x, 9.x` / `8.x, 9.x`）は変更していません**。

## 確認事項

- `textlint` 通過（変更 3 ファイル）。
- `ja/admin-guide/upgrading/` 配下の全ファイルについて、`Node.js` / `MongoDB` / `Elasticsearch` の表行と直近の見出しを突き合わせ、同種のラベル誤記が他に無いことを確認済み。
- 変更は 3 行のみで、対応バージョンの値そのものには手を入れていません。

## #604 との関係

本 PR は #604 から独立してマージできます（マージ順の制約はありません）。

#604 側の `upgrading/README.md`（日英）には、当初 `80x.md` から引き写した Elasticsearch の対応表がありましたが、**表そのものを削除**しました。概要ページは「現在のバージョンから最新バージョンへ直接上げる」ことを前提としており、読者に必要なのは次の 1 点に尽きるためです。

> GROWI v8.0.x が対応するのは v8 系・v9 系のみです（既定の利用バージョンは v9 系）。

「どのバージョンの GROWI がどの Elasticsearch に対応するか」という一覧は、本来「本体より先に Elasticsearch だけ移行してよいか」を判断するための情報ですが、#604 では**ミドルウェアの先行移行そのものを禁止する警告**（本体を停止し、同じ作業の中で実施する）を入れたため、その判断が発生しなくなりました。

したがって #604 側と本 PR の表が食い違うことはありません。
