### PR TITLE
docs(getting-started): document the MongoDB replica set required from v8.0

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -34,6 +34,7 @@ Set `WorkingDirectory` to the directory where GROWI is located. If you have foll
 #### Environment
 
 Set environment variables such as `MONGO_URI` and `FILE_UPLOAD`.
+When you connect to Elasticsearch 8.x, also set `ELASTICSEARCH_VERSION=8`. GROWI defaults to `9`.
 
 #### ExecStart
 

--- a/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -16,7 +16,7 @@ After=network.target mongod.service
 [Service]
 WorkingDirectory=/opt/growi
 Environment=PORT=3000\
-MONGO_URI=mongodb://localhost:27017/growi\
+MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0\
 ELASTICSEARCH_URI=http://localhost:9200/growi
 ExecStart=/usr/bin/npm run app:server
 

--- a/docs/en/admin-guide/admin-cookbook/multi-app.md
+++ b/docs/en/admin-guide/admin-cookbook/multi-app.md
@@ -37,7 +37,7 @@ services:
       - elasticsearch
     environment:
       # Use the same paths for app-1 in MONGO_URI and ELASTICSEARCH_URI
-      - MONGO_URI=mongodb://mongo:27017/growi-1
+      - MONGO_URI=mongodb://mongo:27017/growi-1?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-1
       - PASSWORD_SEED=changeme
     command: "dockerize
@@ -62,7 +62,7 @@ services:
       - elasticsearch
     environment:
       # Use the same paths for app-2 in MONGO_URI and ELASTICSEARCH_URI
-      - MONGO_URI=mongodb://mongo:27017/growi-2
+      - MONGO_URI=mongodb://mongo:27017/growi-2?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-2
       - PASSWORD_SEED=changeme
     command: "dockerize
@@ -87,7 +87,7 @@ services:
       - elasticsearch
     environment:
       # Use the same paths for app-3 in MONGO_URI and ELASTICSEARCH_URI
-      - MONGO_URI=mongodb://mongo:27017/growi-3
+      - MONGO_URI=mongodb://mongo:27017/growi-3?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-3
       - PASSWORD_SEED=changeme
     command: "dockerize

--- a/docs/en/admin-guide/getting-started/ubuntu-server.md
+++ b/docs/en/admin-guide/getting-started/ubuntu-server.md
@@ -310,6 +310,38 @@ $ systemctl status mongod
 ...
 ```
 
+### Enabling a replica set configuration
+
+From GROWI v8.0, GROWI uses MongoDB change streams, so MongoDB has to run as a replica set. A single-node replica set is acceptable.
+
+Add the replica set name to `/etc/mongod.conf`. This example uses `rs0`.
+
+```yaml
+replication:
+  replSetName: rs0
+```
+
+Restart MongoDB to apply the setting.
+
+```bash
+$ sudo systemctl restart mongod
+```
+
+Initiate the replica set. This is only needed the first time.
+
+```bash
+$ mongosh --eval 'rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] })'
+```
+
+Check that this member has become `PRIMARY`.
+
+```bash
+$ mongosh --eval 'rs.status().members[0].stateStr'
+PRIMARY
+```
+
+GROWI connects to it with `?replicaSet=rs0` in `MONGO_URI` (see "Startup verification" below).
+
 ## GROWI
 
 ### Installation
@@ -366,7 +398,7 @@ Please modify `MONGO_URI` and `ELASTICSEARCH_URI` according to your environment.
 
 ```bash
 $ sudo \
-MONGO_URI=mongodb://localhost:27017/growi \
+MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
 npm run app:server
 

--- a/docs/en/admin-guide/getting-started/ubuntu-server.md
+++ b/docs/en/admin-guide/getting-started/ubuntu-server.md
@@ -8,11 +8,11 @@ This chapter introduces how to install GROWI on Ubuntu Server 22.04 (Jammy). Oth
 
 The software required for setup is as follows:
 
-* node.js 18.x or 20.x
-* npm 6.x
+* Node.js 24.x
+* npm 11.x (bundled with Node.js 24.x)
 * pnpm
-* MongoDB 4.4 or higher (6.0 or higher recommended)
-* (Option) Elasticsearch 7.x or 8.x
+* MongoDB 6.0 or higher (a replica set configuration is required)
+* (Option) Elasticsearch 8.x or 9.x
 * (Option) systemd
 * (Option) Apache or nginx
 
@@ -28,7 +28,7 @@ Install `git` and `curl` which are required during the installation process.
 $ sudo apt update && sudo apt -y install git curl
 ```
 
-## Installing node.js 20.x & npm
+## Installing Node.js 24.x & npm
 
 ### Using NodeSource repository
 
@@ -38,7 +38,7 @@ Get the Node.js installation script from [https://deb.nodesource.com/](https://d
 
 ```bash
 $ cd ~
-$ curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+$ curl -sL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh
 ```
 
 Execute the downloaded script.
@@ -55,30 +55,24 @@ $ sudo apt -y install nodejs
 
 Since GROWI uses pnpm for package installation, install the `pnpm` command here.
 
-For the `<version>` part, please check the official site information and select appropriately.
+For the `<version>` part, use the value that the GROWI you are installing declares in `packageManager` in its `package.json` (v8.0.0 declares `pnpm@11.1.1`).
 
 ```bash
 $ curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=<version> sudo sh -
 $ sudo pnpm setup
 ```
 
-Also, since GROWI uses Turborepo for building, install the `turbo` command.
+GROWI uses Turborepo for building, but `turbo` is in devDependencies, so `pnpm install` below installs it. You do not need to install it globally.
 
-```bash
-$ sudo pnpm add turbo --global
-```
-
-After installing Node.js, npm, pnpm, and turbo, check the installed versions.
+After installing Node.js, npm, and pnpm, check the installed versions.
 
 ```bash
 $ nodejs -v
-v20.12.2
+v24.14.0
 $ npm -v
-10.5.0
+11.9.0
 $ pnpm -v
-9.12.2
-$ turbo --version
-2.1.3
+11.1.1
 ```
 
 ## Elasticsearch
@@ -86,6 +80,8 @@ $ turbo --version
 ### Installation
 
 Follow the [official page](https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html) to proceed with installation. Here we install Elasticsearch 8.x.
+
+GROWI v8.0 supports Elasticsearch 8.x and 9.x. GROWI defaults to 9.x, so when you use 8.x, set the environment variable `ELASTICSEARCH_VERSION` to `8` (see "Startup verification" below).
 
 First, install JDK17 to run Elasticsearch.
 
@@ -394,12 +390,13 @@ After the build is complete, perform startup verification.
 
 This assumes that MongoDB and Elasticsearch are running on the same host.
 
-Please modify `MONGO_URI` and `ELASTICSEARCH_URI` according to your environment.
+Please modify `MONGO_URI` and `ELASTICSEARCH_URI` according to your environment. `ELASTICSEARCH_VERSION` takes the major version of the Elasticsearch you connect to. The steps on this page install 8.x, so set it to `8` (GROWI defaults to `9`).
 
 ```bash
 $ sudo \
 MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
+ELASTICSEARCH_VERSION=8 \
 npm run app:server
 
 ...

--- a/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -34,7 +34,8 @@ GROWI のディレクトリのある場所を指定します。
 #### Environment
 
 環境変数を指定します。  
-`MONGO_URI` や `FILE_UPLOAD` などをここで指定します。
+`MONGO_URI` や `FILE_UPLOAD` などをここで指定します。  
+Elasticsearch 8.x に接続する場合は `ELASTICSEARCH_VERSION=8` も指定してください。GROWI の既定値は `9` です。
 
 #### ExecStart
 

--- a/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -16,7 +16,7 @@ After=network.target mongod.service
 [Service]
 WorkingDirectory=/opt/growi
 Environment=PORT=3000\
-MONGO_URI=mongodb://localhost:27017/growi\
+MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0\
 ELASTICSEARCH_URI=http://localhost:9200/growi
 ExecStart=/usr/bin/npm run app:server
 

--- a/docs/ja/admin-guide/admin-cookbook/multi-app.md
+++ b/docs/ja/admin-guide/admin-cookbook/multi-app.md
@@ -37,7 +37,7 @@ services:
       - elasticsearch
     environment:
       # この MONGO_URI と ELASTICSEARCH_URI のパス名は app-1 用のものに揃えてください
-      - MONGO_URI=mongodb://mongo:27017/growi-1
+      - MONGO_URI=mongodb://mongo:27017/growi-1?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-1
       - PASSWORD_SEED=changeme
     command: "dockerize
@@ -62,7 +62,7 @@ services:
       - elasticsearch
     environment:
       # この MONGO_URI と ELASTICSEARCH_URL のパス名は app-2 用のものに揃えてください
-      - MONGO_URI=mongodb://mongo:27017/growi-2
+      - MONGO_URI=mongodb://mongo:27017/growi-2?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-2
       - PASSWORD_SEED=changeme
     command: "dockerize
@@ -87,7 +87,7 @@ services:
       - elasticsearch
     environment:
       # この MONGO_URI と ELASTICSEARCH_URI のパス名は app-3 用のものに揃えてください
-      - MONGO_URI=mongodb://mongo:27017/growi-3
+      - MONGO_URI=mongodb://mongo:27017/growi-3?replicaSet=rs0
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi-3
       - PASSWORD_SEED=changeme
     command: "dockerize

--- a/docs/ja/admin-guide/getting-started/almalinux.md
+++ b/docs/ja/admin-guide/getting-started/almalinux.md
@@ -8,11 +8,11 @@
 
 セットアップに必要となるソフトウェアは以下の通りです。
 
-* node.js 18.x or 20.x
-* npm 6.x
+* Node.js 24.x
+* npm 11.x \(Node.js 24.x に同梱\)
 * pnpm
-* MongoDB 4.4 以上 \(6.0 以上を推奨\)
-* \(Option\) Elasticsearch 7.x or 8.x
+* MongoDB 6.0 以上 \(レプリカセット構成が必須\)
+* \(Option\) Elasticsearch 8.x or 9.x
 * \(Optional\) systemd
 * \(Optional\) Apache or nginx
 
@@ -20,7 +20,7 @@
 Optional となっているものは必須ではありません。ただし、本項ではこれら全てを利用し、全文検索できる GROWI を Apache or nginx でリバースプロキシする環境を構築し、systemd でホストと同時に起動させる方法を説明します。
 <!-- textlint-enable weseek/no-doubled-joshi -->
 
-## node.js 20.x & npm のインストール
+## Node.js 24.x & npm のインストール
 
 ### NodeSource repository を利用する
 
@@ -30,7 +30,7 @@ Optional となっているものは必須ではありません。ただし、�
 
 ```text
 $ cd ~
-$ curl -sL https://rpm.nodesource.com/setup_20.x -o nodesource_setup.sh
+$ curl -sL https://rpm.nodesource.com/setup_24.x -o nodesource_setup.sh
 ```
 
 取得したスクリプトを実行します。
@@ -47,28 +47,24 @@ $ sudo dnf install -y nodejs
 
 GROWI では pnpm を用いたパッケージインストールを利用するため、ここで `pnpm` コマンドをインストールしておきます。
 
+`<version>` 部分は、インストールする GROWI が `package.json` の `packageManager` で宣言している値に合わせてください（v8.0.0 は `pnpm@11.1.1`）。
+
 ```text
 $ curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=<version> sudo sh -
 $ sudo pnpm setup
 ```
 
-また、GROWI では Turborepo を用いてビルドを行うため、`turbo` コマンドをインストールします。
+GROWI は Turborepo を用いてビルドしますが、`turbo` は devDependencies に含まれるため、後述の `pnpm install` で導入されます。グローバルインストールは不要です。
 
-```text
-$ sudo pnpm add turbo --global
-```
-
-Node.js, npm, pnpm, turbo のインストールが完了したら、インストールしたバージョンを確認しましょう。
+Node.js, npm, pnpm のインストールが完了したら、インストールしたバージョンを確認しましょう。
 
 ```text
 $ node -v
-v20.12.2
+v24.14.0
 $ npm -v
-10.5.0
+11.9.0
 $ pnpm -v
-9.12.2
-$ turbo --version
-2.1.3
+11.1.1
 ```
 
 ## Elasticsearch
@@ -76,6 +72,8 @@ $ turbo --version
 ### インストール
 
 [公式ページ](https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html) に従い、インストールを進めます。 ここでは Elasticsearch 8.x をインストールします。
+
+GROWI v8.0 が対応する Elasticsearch は 8.x・9.x です。GROWI 側の既定は 9.x のため、8.x を利用する場合は環境変数 `ELASTICSEARCH_VERSION` に `8` を指定します（後述の「起動確認」を参照）。
 
 まず、 Elasticsearch を実行できるように JDK17 をインストールします。
 
@@ -406,12 +404,13 @@ success
 
 ここでは MongoDB と Elasticsearch が同一ホストで稼働していることを前提としています。
 
-`MONGO_URI` と `ELASTICSEARCH_URI` は環境に合わせて適宜書き換えてください。
+`MONGO_URI` と `ELASTICSEARCH_URI` は環境に合わせて適宜書き換えてください。`ELASTICSEARCH_VERSION` には、接続先 Elasticsearch のメジャーバージョンを指定します。本ページの手順では 8.x をインストールしているため `8` を指定します（GROWI 側の既定値は `9` です）。
 
 ```text
 $ sudo \
 MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
+ELASTICSEARCH_VERSION=8 \
 npm run app:server
 
 ...

--- a/docs/ja/admin-guide/getting-started/almalinux.md
+++ b/docs/ja/admin-guide/getting-started/almalinux.md
@@ -293,6 +293,38 @@ $ systemctl status mongod
 ...
 ```
 
+### レプリカセット構成の有効化
+
+GROWI v8.0 以降は MongoDB の change stream を利用するため、MongoDB をレプリカセット構成で運用する必要があります。単一ノードのレプリカセットでも構いません。
+
+`/etc/mongod.conf` に、レプリカセット名を追記します。ここでは `rs0` とします。
+
+```yaml
+replication:
+  replSetName: rs0
+```
+
+設定を反映するため、MongoDB を再起動します。
+
+```text
+$ sudo systemctl restart mongod
+```
+
+レプリカセットを初期化します。この操作が必要なのは初回のみです。
+
+```text
+$ mongosh --eval 'rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] })'
+```
+
+このノードが `PRIMARY` になったことを確認します。
+
+```text
+$ mongosh --eval 'rs.status().members[0].stateStr'
+PRIMARY
+```
+
+GROWI からは、`MONGO_URI` に `?replicaSet=rs0` を付けて接続します（後述の「起動確認」を参照）。
+
 ## GROWI
 
 ### Git LFS の導入
@@ -378,7 +410,7 @@ success
 
 ```text
 $ sudo \
-MONGO_URI=mongodb://localhost:27017/growi \
+MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
 npm run app:server
 

--- a/docs/ja/admin-guide/getting-started/ubuntu-server.md
+++ b/docs/ja/admin-guide/getting-started/ubuntu-server.md
@@ -8,11 +8,11 @@
 
 セットアップに必要となるソフトウェアは以下の通りです。
 
-* node.js 18.x or 20.x
-* npm 6.x
+* Node.js 24.x
+* npm 11.x \(Node.js 24.x に同梱\)
 * pnpm
-* MongoDB 4.4 以上 \(6.0 以上を推奨\)
-* \(Option\) Elasticsearch 7.x or 8.x
+* MongoDB 6.0 以上 \(レプリカセット構成が必須\)
+* \(Option\) Elasticsearch 8.x or 9.x
 * \(Option\) systemd
 * \(Option\) Apache or nginx
 
@@ -28,7 +28,7 @@ Optional となっているものは必須ではありません。ただし、�
 $ sudo apt update && sudo apt -y install git curl
 ```
 
-## node.js 20.x & npm のインストール
+## Node.js 24.x & npm のインストール
 
 ### NodeSource repository を利用する
 
@@ -38,7 +38,7 @@ $ sudo apt update && sudo apt -y install git curl
 
 ```bash
 $ cd ~
-$ curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+$ curl -sL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh
 ```
 
 取得したスクリプトを実行します。
@@ -55,30 +55,24 @@ $ sudo apt -y install nodejs
 
 GROWI では pnpm を用いたパッケージインストールを利用するため、ここで `pnpm` コマンドをインストールしておきます。
 
-`<version>` 部分は公式サイトの情報を確認し、適宜選択してください。
+`<version>` 部分は、インストールする GROWI が `package.json` の `packageManager` で宣言している値に合わせてください（v8.0.0 は `pnpm@11.1.1`）。
 
 ```bash
 $ curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=<version> sudo sh -
 $ sudo pnpm setup
 ```
 
-また、GROWI では Turborepo を用いてビルドを行うため、`turbo` コマンドをインストールします。
+GROWI は Turborepo を用いてビルドしますが、`turbo` は devDependencies に含まれるため、後述の `pnpm install` で導入されます。グローバルインストールは不要です。
 
-```bash
-$ sudo pnpm add turbo --global
-```
-
-Node.js, npm, pnpm, turbo のインストールが完了したら、インストールしたバージョンを確認しましょう。
+Node.js, npm, pnpm のインストールが完了したら、インストールしたバージョンを確認しましょう。
 
 ```bash
 $ nodejs -v
-v20.12.2
+v24.14.0
 $ npm -v
-10.5.0
+11.9.0
 $ pnpm -v
-9.12.2
-$ turbo --version
-2.1.3
+11.1.1
 ```
 
 ## Elasticsearch
@@ -86,6 +80,8 @@ $ turbo --version
 ### インストール
 
 [公式ページ](https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html) に従い、インストールを進めます。 ここでは Elasticsearch 8.x をインストールします。
+
+GROWI v8.0 が対応する Elasticsearch は 8.x・9.x です。GROWI 側の既定は 9.x のため、8.x を利用する場合は環境変数 `ELASTICSEARCH_VERSION` に `8` を指定します（後述の「起動確認」を参照）。
 
 まず、Elasticsearch を実行できるように JDK17 をインストールします。
 
@@ -394,12 +390,13 @@ $ pnpm run app:build
 
 ここでは MongoDB と Elasticsearch が同一ホストで稼働していることを前提としています。
 
-`MONGO_URI` と `ELASTICSEARCH_URI` は環境に合わせて適宜書き換えてください。
+`MONGO_URI` と `ELASTICSEARCH_URI` は環境に合わせて適宜書き換えてください。`ELASTICSEARCH_VERSION` には、接続先 Elasticsearch のメジャーバージョンを指定します。本ページの手順では 8.x をインストールしているため `8` を指定します（GROWI 側の既定値は `9` です）。
 
 ```bash
 $ sudo \
 MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
+ELASTICSEARCH_VERSION=8 \
 npm run app:server
 
 ...

--- a/docs/ja/admin-guide/getting-started/ubuntu-server.md
+++ b/docs/ja/admin-guide/getting-started/ubuntu-server.md
@@ -310,6 +310,38 @@ $ systemctl status mongod
 ...
 ```
 
+### レプリカセット構成の有効化
+
+GROWI v8.0 以降は MongoDB の change stream を利用するため、MongoDB をレプリカセット構成で運用する必要があります。単一ノードのレプリカセットでも構いません。
+
+`/etc/mongod.conf` に、レプリカセット名を追記します。ここでは `rs0` とします。
+
+```yaml
+replication:
+  replSetName: rs0
+```
+
+設定を反映するため、MongoDB を再起動します。
+
+```bash
+$ sudo systemctl restart mongod
+```
+
+レプリカセットを初期化します。この操作が必要なのは初回のみです。
+
+```bash
+$ mongosh --eval 'rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] })'
+```
+
+このノードが `PRIMARY` になったことを確認します。
+
+```bash
+$ mongosh --eval 'rs.status().members[0].stateStr'
+PRIMARY
+```
+
+GROWI からは、`MONGO_URI` に `?replicaSet=rs0` を付けて接続します（後述の「起動確認」を参照）。
+
 ## GROWI
 
 ### インストール
@@ -366,7 +398,7 @@ $ pnpm run app:build
 
 ```bash
 $ sudo \
-MONGO_URI=mongodb://localhost:27017/growi \
+MONGO_URI=mongodb://localhost:27017/growi?replicaSet=rs0 \
 ELASTICSEARCH_URI=http://localhost:9200/growi \
 npm run app:server
 


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/188315

## 概要

インストールガイドと Cookbook の `MONGO_URI` の記載例が standalone 構成の MongoDB を指していたため、レプリカセット構成の URI に改めました。あわせて、レプリカセット構成を有効化する手順をインストールガイドへ追加しています。

GROWI v8.0 以降は MongoDB の change stream を利用するため、レプリカセット構成が必須です（[v8.0.x へのアップグレード](https://docs.growi.org/ja/admin-guide/upgrading/80x.html) 参照）。ガイドに従うと standalone 構成で構築され、`MONGO_URI` にもレプリカセットの指定がないため、そのままでは v8.0 以降を動かせない状態でした。

#604 のレビューで「`MONGO_URI` がレプリカセット運用の URL になっていない。元の記載も変える必要があるかも」とご指摘いただいた、その「元」に当たる修正です。

## 変更内容

**レプリカセット構成の有効化手順を追加**（MongoDB を起動した直後の節として挿入）

- `admin-guide/getting-started/ubuntu-server.md`（日英）
- `admin-guide/getting-started/almalinux.md`（日。英語版は存在しません）

`/etc/mongod.conf` への `replSetName` の追記 → `mongod` の再起動 → `rs.initiate()` による初期化 → `PRIMARY` になったことの確認、という流れです。レプリカセット名は [growi-docker-compose](https://github.com/growilabs/growi-docker-compose) と同じ `rs0` を例にしています。

**`MONGO_URI` の記載例を `?replicaSet=rs0` 付きに変更**

- 上記 3 ファイルの「起動確認」
- `admin-guide/admin-cookbook/launch-with-systemd.md`（日英）: systemd ユニットの `Environment=`
- `admin-guide/admin-cookbook/multi-app.md`（日英）: 3 アプリ分の `MONGO_URI`（`mongo` サービス自体は growi-docker-compose の定義をそのまま使うため、そちらは既にレプリカセット構成です）

**前提条件と Node.js / Elasticsearch の記載を v8.0 に追従**（レビューでのご指摘を受けて追加）

インストールガイドは Node.js 18/20・MongoDB 4.4 以上を要求する記載のままで、そのまま従うと v8.0 を動かせない環境ができていました。GROWI v8.0 がサポートするのは Node.js v24 系のみ・Elasticsearch v8/v9 系のみで、MongoDB は v6.0 以上が必要です。

- `getting-started/ubuntu-server.md`（日英）・`almalinux.md`（日）の前提条件を Node.js 24.x / npm 11.x / MongoDB 6.0 以上（レプリカセット必須）/ Elasticsearch 8.x or 9.x に更新
- Node.js のインストールを `setup_24.x` に変更し、見出しとバージョン確認例（`v24.14.0` / `11.9.0` / `11.1.1`）も揃えました
- `turbo` のグローバルインストール手順を削除。`turbo` は devDependencies に含まれるため `pnpm install` で導入されます。あわせて pnpm のバージョンは `package.json` の `packageManager` の宣言（v8.0.0 は `pnpm@11.1.1`）に合わせるよう明記
- **起動時に `ELASTICSEARCH_VERSION=8` を指定するよう追記**。本ガイドは Elasticsearch 8.x をインストールしますが、GROWI 側の既定値は `9` なので、指定しないと全文検索の初期化に失敗します。`admin-cookbook/launch-with-systemd.md`（日英）の `Environment` の説明にも同じ注意を書きました

## 変更しなかったもの

- `admin-guide/getting-started/centos.md`（日英）: MongoDB 3.6 / node.js 8.x をインストールするページで、そもそも v8.0 を動かせる構成ではありません。standalone 構成の記述として内部で一貫しているため、そのまま残しています。
- `admin-guide/admin-cookbook/env-vars.md` の `MONGO_URI` の既定値（`mongodb://localhost/growi`）: GROWI 本体の既定値そのものなので変更しません。
- `admin-guide/downgrading/50x-to-45x.md`、`migration-guide/from-crowi-onpremise.md`、`upgrading/36x.md`: v8.0 より前を対象とした記述です。

## 追従しなかった範囲（意図的）

**ミドルウェアのインストール対象バージョンは据え置き**にしています。Elasticsearch は 8.x、MongoDB は 6.0 のままで、どちらも GROWI v8.0 のサポート範囲内です。

- **Elasticsearch を 9.x へ引き上げていない理由**: 本ガイドの「TLS の無効化」節は、8.x の既定 `elasticsearch.yml` に対する literal な unified diff です。9.x 用の同等の diff を実機確認なしに書き換えると、検証していない手順を載せることになります。代わりに `ELASTICSEARCH_VERSION=8` の指定を明記して、8.x のままでも正しく動く形にしました。
- **MongoDB を 8.0 へ引き上げていない理由**: 6.0 は v8.0 のサポート範囲内かつアップグレードガイドが示す下限です。リポジトリ URL・GPG キー・`dnf` / `dpkg` の出力例まで差し替える範囲になるため、別途としました。

いずれも「古いがサポート内」の状態なので、追従は別 PR で扱えます。今回直したのは「そのまま従うと v8.0 が動かない」部分（Node.js のバージョンと `ELASTICSEARCH_VERSION` の欠落）です。

## 確認事項

- `pnpm lint`（textlint）クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
