### PR TITLE
docs(v8): clarify AI force-disable and clean up AI env vars

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/en/admin-guide/admin-cookbook/env-vars.md
@@ -96,21 +96,6 @@ pageClass: admin-cookbook-env-vars
 | `OPENTELEMETRY_ANONYMIZE_IN_BEST_EFFORT` | Applies additional anonymization to data sent via OpenTelemetry. While sensitive information is not sent under normal circumstances, enabling this setting provides an extra layer of protection for environments requiring stricter data anonymization. Note that enabling this may have a slight impact on server performance. | `false` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint for data transmission | `https://telemetry.growi.org` |
 | Other environment variables starting with `OTEL_` | Refer to the official OpenTelemetry documentation.<ul><li><a href="https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/">Environment Variable Specification</a></li><li><a href="https://opentelemetry.io/docs/languages/sdk-configuration/">SDK Configuration</a></li></ul> |  |
-| **Option for GROWI AI features** |  |  |
-| `AI_ENABLED` | Enable or disable AI function | `false` |
-| `OPENAI_SERVICE_TYPE` | Type of OpenAI compatible service. As of v7.1.2, only `openai` is available. | `openai` |
-|  | : `openai` Use OpenAI API. |  | <!-- TODO: add "`azure-openai`: Use "Azure OpenAI"" -->|
-| `OPENAI_API_KEY` | API key for using OpenAI services. |  |
-| `OPENAI_CHAT_ASSISTANT_INSTRUCTIONS` | Instructions used by Knowledge Assistant feature. | [ref](https://github.com/growilabs/growi/blob/82042b3a409e867615acedd9fb3e99f3236c1917/apps/app/src/server/service/config-manager/config-definition.ts#L1077) |
-| `OPENAI_CHAT_ASSISTANT_MODEL` | AI model used by Knowledge Assistant feature. | `gpt-4o-mini` |
-| `OPENAI_THREAD_DELETION_CRON_EXPRESSION` | Specifies the schedule for executing OpenAI thread deletion in cron format. | `0 * * * *` |
-| `OPENAI_THREAD_DELETION_BARCH_SIZE` | Maximum number of threads to delete in a single process | 100 |
-| `OPENAI_THREAD_DELETION_API_CALL_INTERVAL` | Interval between thread deletion API calls (milliseconds) | 36000 |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_CRON_EXPRESSION` | Specifies the schedule for executing Vector store file deletion in cron format. | `0 * * * *` |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_BARCH_SIZE` | Maximum number of Vector store files to delete in a single process | 100 |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_API_CALL_INTERVAL` | Interval between Vector store file deletion API calls (milliseconds) | 36000 |
-| `OPENAI_SEARCH_ASSISTANT_INSTRUCTIONS` | Instructions used for Search Assistant functionality | `''` (empty string) |
-| `OPENAI_LIMIT_LEARNABLE_PAGE_COUNT_PER_ASSISTANT` | Maximum number of pages that a single Knowledge Assistant can learn | 3000 |
 | **GROWI AI Agent options** |  |  |
 | `AI_ENABLED` | Enables GROWI AI Agent when `true`. | `false` |
 | `AI_PROVIDERS` | Specifies per-provider settings (enabling, Azure OpenAI settings, etc.) as JSON.<br>Example: `{"openai":{"enabled":true},"azure-openai":{"enabled":true,"azureOpenaiSettings":{"resourceName":"<resource-name>"}}}` |  |
@@ -119,6 +104,10 @@ pageClass: admin-cookbook-env-vars
 | `AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS` | When `true`, the connection settings (enabling the AI feature, enabling providers, and API keys) reference only the environment variable values, not the values in the local DB. | `false` |
 | `AI_MODEL_CATALOG_REFRESH_ON_STARTUP` | When `true`, refreshes the model catalog on startup. | `false` |
 | `AI_MODEL_CATALOG_REFRESH_CRON_SCHEDULE` | Specifies the schedule for periodically refreshing the model catalog in cron format. Leave empty to disable periodic refresh. | `0 4 * * *` |
+| `AI_SUGGEST_PATH_AGENT_PROVIDER_OPTIONS` | Overrides the model's providerOptions for the path suggestion (suggest-path) agent only, as JSON. When empty, the model catalog's options are used as-is.<br>Example: `{"openai":{"reasoningEffort":"minimal"}}` |  |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_SEARCH_LIMIT` | Maximum number of pages the path suggestion agent retrieves per search. | 5 |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_CHILD_LISTING_LIMIT` | Maximum number of entries the path suggestion agent retrieves when listing child pages. | 5 |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_TIMEOUT_MS` | Timeout (in milliseconds) for the path suggestion agent's processing. | 60000 |
 | **Option (Overwritable in admin page)** | | |
 | `APP_SITE_URL_USES_ONLY_ENV_VARS` | Prioritize env vars over values in DB for Site URL | `false` |
 | `FILE_UPLOAD_USES_ONLY_ENV_VAR_FOR_FILE_UPLOAD_TYPE` | Prioritize env var over value in DB for File Upload Type | `false` |

--- a/docs/en/admin-guide/upgrading/80x.md
+++ b/docs/en/admin-guide/upgrading/80x.md
@@ -107,6 +107,25 @@ If you previously switched the scope of auto-instrumentation with an environment
 
 </ContextualBlock>
 
+<ContextualBlock context="docs-growi-org">
+
+### [Note] Locking the AI feature on or off with environment variables alone
+
+`AI_ENABLED` provides the **initial value** for the AI feature. In GROWI, configuration values are resolved in the order "environment variable → admin panel (DB) value", so a value saved from the admin panel takes precedence over the environment variable. As a result, `AI_ENABLED=false` alone does not prevent an administrator from enabling the AI feature from **AI Settings** in the admin panel.
+
+To make GROWI reference only the environment variable value and reject changes from the admin panel, also set `AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS=true`. When this flag is `true`, enabling/disabling the AI feature, enabling providers, and the API keys are read only from the environment variables, and changes from the admin panel are rejected.
+
+To completely disable the AI feature and prevent it from being enabled via the admin panel, set both:
+
+```yaml
+AI_ENABLED: "false"
+AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: "true"
+```
+
+For details on each environment variable, see [Environment variables](/en/admin-guide/admin-cookbook/env-vars.html).
+
+</ContextualBlock>
+
 
 ## Things to Check Before Upgrading
 

--- a/docs/ja/admin-guide/admin-cookbook/env-vars.md
+++ b/docs/ja/admin-guide/admin-cookbook/env-vars.md
@@ -97,21 +97,6 @@ pageClass: admin-cookbook-env-vars
 | `OPENTELEMETRY_ANONYMIZE_IN_BEST_EFFORT` | OpenTelemetry で送信されるデータに対して、追加の匿名化処理を行います。通常状態でも機密情報が送信されることはありませんが、より慎重にデータを匿名化したい環境においては、この設定を有効にすることで追加の保護層を提供できます。有効にした場合、わずかながらサーバーパフォーマンスに影響する可能性があります。 | `false` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | データ送信先エンドポイント | `https://telemetry.growi.org` |
 | その他の `OTEL_` で始まる環境変数 | OpenTelemetry 公式ドキュメントを参照してください。<ul><li><a href="https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/">Environment Variable Specification</a></li><li><a href="https://opentelemetry.io/docs/languages/sdk-configuration/">SDK Configuration</a></li></ul> |  |
-| **GROWI AI オプション** |  |  |
-| `AI_ENABLED` | `true` の場合、AI 連携を有効にします。 | `false` |
-| `OPENAI_SERVICE_TYPE` | 利用する OpenAI 互換サービスの種別。v7.1.2 時点では `openai` のみ利用可能です。 | `openai` |
-|  | : `openai` OpenAI API を利用します |  | <!-- TODO: 使えるようになったら、新しい行にこれを追加「`azure-openai`: Azure OpenAI を利用」 -->
-| `OPENAI_API_KEY` | OpenAI サービスで取得した API キーを指定します。 |  |
-| `OPENAI_CHAT_ASSISTANT_INSTRUCTIONS` | ナレッジアシスタントで利用されるインストラクション | [ref](https://github.com/growilabs/growi/blob/82042b3a409e867615acedd9fb3e99f3236c1917/apps/app/src/server/service/config-manager/config-definition.ts#L1077) |
-| `OPENAI_CHAT_ASSISTANT_MODEL` | ナレッジアシスタント機能で利用されるモデル | `gpt-4o-mini` |
-| `OPENAI_THREAD_DELETION_CRON_EXPRESSION` | OpenAI スレッドの削除を実行するスケジュールを cron 形式で指定します。 | `0 * * * *` |
-| `OPENAI_THREAD_DELETION_BARCH_SIZE` | 一度の処理で削除するスレッドの最大数 | 100 |
-| `OPENAI_THREAD_DELETION_API_CALL_INTERVAL` | スレッド削除 API 呼び出しの間隔（ミリ秒） | 36000 |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_CRON_EXPRESSION` | Vector store ファイルの削除を実行するスケジュールを cron 形式で指定します。 | `0 * * * *` |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_BARCH_SIZE` | 一度の処理で削除する Vector store ファイルの最大数 | 100 |
-| `OPENAI_VECTOR_STORE_FILE_DELETION_API_CALL_INTERVAL` | Vector store ファイル削除 API 呼び出しの間隔（ミリ秒） | 36000 |
-| `OPENAI_SEARCH_ASSISTANT_INSTRUCTIONS` | 検索アシスタント機能で利用されるインストラクション | `''` (空文字列) |
-| `OPENAI_LIMIT_LEARNABLE_PAGE_COUNT_PER_ASSISTANT` | 1つのナレッジアシスタントが学習できるページの上限数  | 3000  |
 | **GROWI AI Agent オプション** |  |  |
 | `AI_ENABLED` | `true` の場合、GROWI AI Agent を有効にします。 | `false` |
 | `AI_PROVIDERS` | プロバイダごとの設定（有効化・Azure OpenAI 設定など）を JSON で指定します。<br>例: `{"openai":{"enabled":true},"azure-openai":{"enabled":true,"azureOpenaiSettings":{"resourceName":"<リソース名>"}}}` |  |
@@ -120,6 +105,10 @@ pageClass: admin-cookbook-env-vars
 | `AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS` | `true` の場合、接続設定（AI 機能の有効化・プロバイダの有効化・API キー）はローカル DB の値を参照せず、環境変数の値のみを参照します。 | `false` |
 | `AI_MODEL_CATALOG_REFRESH_ON_STARTUP` | `true` の場合、起動時にモデルカタログを更新します。 | `false` |
 | `AI_MODEL_CATALOG_REFRESH_CRON_SCHEDULE` | モデルカタログを定期更新するスケジュールを cron 形式で指定します。空にすると定期更新を無効化します。 | `0 4 * * *` |
+| `AI_SUGGEST_PATH_AGENT_PROVIDER_OPTIONS` | パス候補提案（suggest-path）のエージェント専用に、モデルの providerOptions を JSON で上書き指定します。空の場合はモデルカタログの設定がそのまま使われます。<br>例: `{"openai":{"reasoningEffort":"minimal"}}` |  |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_SEARCH_LIMIT` | パス候補提案のエージェントが 1 回の検索で取得するページ数の上限。 | 5 |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_CHILD_LISTING_LIMIT` | パス候補提案のエージェントが子ページ一覧を取得する際の件数上限。 | 5 |
+| `AI_TOOLS_SUGGEST_PATH_AGENTIC_TIMEOUT_MS` | パス候補提案のエージェント処理のタイムアウト（ミリ秒）。 | 60000 |
 | **管理設定を上書きする環境変数** | | |
 | `APP_SITE_URL_USES_ONLY_ENV_VARS` | `true` の場合、サイト URL の設定値はローカル DB の値を参照せず、環境変数の値のみを参照します。 | `false` |
 | `FILE_UPLOAD_USES_ONLY_ENV_VAR_FOR_FILE_UPLOAD_TYPE` |`true` の場合、ファイルアップロードタイプの設定値はローカル DB の値を参照せず、環境変数の値のみを参照します。|`false`|

--- a/docs/ja/admin-guide/upgrading/80x.md
+++ b/docs/ja/admin-guide/upgrading/80x.md
@@ -107,6 +107,25 @@ Elasticsearch v7 系を利用しているシステムでは、アップグレー
 
 </ContextualBlock>
 
+<ContextualBlock context="docs-growi-org">
+
+### [注意] 環境変数だけで AI 機能の有効・無効を固定する
+
+`AI_ENABLED` は AI 機能の**初期値**を与える環境変数です。GROWI では設定値が「環境変数 → 管理画面（DB）の保存値」の順で解決され、管理画面から保存した値が環境変数より優先されます。そのため `AI_ENABLED=false` だけでは、管理者が管理画面の「AI 設定」から AI 機能を有効化できてしまいます。
+
+環境変数の値だけに固定し、管理画面からの変更を受け付けないようにするには、`AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS=true` を併用してください。このフラグが `true` のとき、AI 機能の有効・無効／プロバイダの有効化／API キーは環境変数の値のみが参照され、管理画面からの変更は拒否されます。
+
+AI 機能を完全に無効化し、管理画面からも有効化できないようにするには、次の 2 つを設定します。
+
+```yaml
+AI_ENABLED: "false"
+AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS: "true"
+```
+
+各環境変数の詳細は [環境変数](/ja/admin-guide/admin-cookbook/env-vars.html) を参照してください。
+
+</ContextualBlock>
+
 
 ## アップグレード前にチェックすべきこと
 


### PR DESCRIPTION
## 概要

GROWI v8.0.x のアップグレードガイドと環境変数リファレンスの AI 関連記述を、日英そろえて整理します。起点は 2 つの issue です。

- growilabs/growi#11638 — `AI_ENABLED=false` 単体では AI 機能を強制無効にできない件
- growilabs/growi#11651 — `OPENAI_SERVICE_TYPE` / `OPENAI_API_KEY` は dead config なので削除

## 変更内容

### `admin-guide/upgrading/80x.md`（ja / en）
- 「[注意] 環境変数だけで AI 機能の有効・無効を固定する」小節を追加。
  - `AI_ENABLED` は初期値のみで、設定解決は「環境変数 → 管理画面(DB)保存値」の順で DB が優先されるため、`AI_ENABLED=false` だけでは管理画面から再有効化できてしまうことを明記。
  - 強制無効かつ管理画面からも変更不可にするには `AI_USES_ONLY_ENV_VARS_FOR_SOME_OPTIONS=true` を併用する必要があることを記載（growilabs/growi#11638 の報告者要望に対応）。

### `admin-guide/admin-cookbook/env-vars.md`（ja / en）
- 旧「GROWI AI オプション」と「GROWI AI Agent オプション」の 2 見出しを 1 つに統合。
- v8.0 で廃止された旧アシスタント系 `OPENAI_*`（`OPENAI_CHAT_ASSISTANT_*` / `OPENAI_SEARCH_ASSISTANT_*` / `OPENAI_THREAD_DELETION_*` / `OPENAI_VECTOR_STORE_FILE_DELETION_*` / `OPENAI_LIMIT_LEARNABLE_PAGE_COUNT_PER_ASSISTANT`）を削除。
- `OPENAI_SERVICE_TYPE` / `OPENAI_API_KEY` を削除。現行の suggest-path-agentic は `AI_PROVIDERS` / `AI_PROVIDER_API_KEYS` / `AI_ALLOWED_MODELS` のみを参照し、この 2 キーはどこからも読まれない dead config のため（growilabs/growi#11651）。
- 現行の suggest-path-agentic 用 env を追記: `AI_SUGGEST_PATH_AGENT_PROVIDER_OPTIONS` / `AI_TOOLS_SUGGEST_PATH_AGENTIC_SEARCH_LIMIT` / `AI_TOOLS_SUGGEST_PATH_AGENTIC_CHILD_LISTING_LIMIT` / `AI_TOOLS_SUGGEST_PATH_AGENTIC_TIMEOUT_MS`。

## 確認

- 追記・削除した env は growilabs/growi の `v8.0.0` タグの `config-definition.ts` と照合済み。
- `textlint` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)